### PR TITLE
refactor: don't make temp overlay update if no gas overlay is displayed

### DIFF
--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -5,9 +5,10 @@
 /turf/var/datum/gas_mixture/air
 
 /turf/simulated/proc/update_graphic(list/graphic_add = null, list/graphic_remove = null)
-	if(graphic_add && length(graphic_add))
+	if(length(graphic_add))
 		vis_contents += graphic_add
-	if(graphic_remove && length(graphic_remove))
+
+	if(length(graphic_remove))
 		vis_contents -= graphic_remove
 
 /turf/proc/update_air_properties()

--- a/code/modules/xgm/xgm_gas_data.dm
+++ b/code/modules/xgm/xgm_gas_data.dm
@@ -54,7 +54,7 @@ var/global/datum/xgm_gas_data/gas_data
 
 /hook/startup/proc/generateGasData()
 	gas_data = new
-	for(var/p in (typesof(/singleton/xgm_gas) - /singleton/xgm_gas))
+	for(var/p in (subtypesof(/singleton/xgm_gas)))
 		var/singleton/xgm_gas/gas = new p //avoid initial() because of potential New() actions
 
 		if(gas.id in gas_data.gases)

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -91,12 +91,12 @@
 	if(!giver)
 		return
 
-	if(abs(temperature-giver.temperature)>MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
+	if(abs(temperature-giver.temperature) > MINIMUM_TEMPERATURE_DELTA_TO_CONSIDER)
 		var/self_heat_capacity = heat_capacity()
 		var/giver_heat_capacity = giver.heat_capacity()
 		var/combined_heat_capacity = giver_heat_capacity + self_heat_capacity
 		if(combined_heat_capacity != 0)
-			temperature = (giver.temperature*giver_heat_capacity + temperature*self_heat_capacity)/combined_heat_capacity
+			temperature = (giver.temperature * giver_heat_capacity + temperature*self_heat_capacity) / combined_heat_capacity
 
 	if((group_multiplier != 1)||(giver.group_multiplier != 1))
 		for(var/g in giver.gas)
@@ -346,60 +346,72 @@
 //Rechecks the gas_mixture and adjusts the graphic list if needed.
 //Two lists can be passed by reference if you need know specifically which graphics were added and removed.
 /datum/gas_mixture/proc/check_tile_graphic(list/graphic_add = null, list/graphic_remove = null)
-	for(var/obj/gas_overlay/O in graphic)
-		if(istype(O, /obj/gas_overlay/heat))
+	for(var/obj/gas_overlay/gas_overlay in graphic)
+		if(istype(gas_overlay, /obj/gas_overlay/heat))
 			continue
-		if(istype(O, /obj/gas_overlay/cold))
+
+		if(istype(gas_overlay, /obj/gas_overlay/cold))
 			continue
-		if(gas[O.gas_id] <= gas_data.overlay_limit[O.gas_id])
-			LAZYADD(graphic_remove, O)
-	for(var/g in gas_data.overlay_limit)
+
+		if(gas[gas_overlay.gas_id] <= gas_data.overlay_limit[gas_overlay.gas_id])
+			LAZYADD(graphic_remove, gas_overlay)
+
+	var/should_generate_temp_overlay = FALSE
+	for(var/gas_id in gas_data.overlay_limit)
 		//Overlay isn't applied for this gas, check if it's valid and needs to be added.
-		if(gas[g] > gas_data.overlay_limit[g])
-			var/tile_overlay = get_tile_overlay(g)
+		if(gas[gas_id] > gas_data.overlay_limit[gas_id])
+			should_generate_temp_overlay = TRUE
+			var/tile_overlay = get_tile_overlay(gas_id)
 			if(!(tile_overlay in graphic))
 				LAZYADD(graphic_add, tile_overlay)
-	. = 0
+	. = FALSE
 
-	var/heat_overlay = get_tile_overlay(GAS_HEAT)
-	//If it's hot add something
-	if(temperature >= CARBON_LIFEFORM_FIRE_RESISTANCE)
-		if(!(heat_overlay in graphic))
-			LAZYADD(graphic_add, heat_overlay)
-	else if (heat_overlay in graphic)
-		LAZYADD(graphic_remove, heat_overlay)
+	if(should_generate_temp_overlay)
+		var/heat_overlay = get_tile_overlay(GAS_HEAT)
+		//If it's hot add something
+		if(temperature >= CARBON_LIFEFORM_FIRE_RESISTANCE)
+			if(!(heat_overlay in graphic))
+				LAZYADD(graphic_add, heat_overlay)
+		else if (heat_overlay in graphic)
+			LAZYADD(graphic_remove, heat_overlay)
 
-	var/cold_overlay = get_tile_overlay(GAS_COLD)
-	if(temperature <= FOGGING_TEMPERATURE && (return_pressure() >= (ONE_ATMOSPHERE / 4)))
-		if(!(cold_overlay in graphic))
-			LAZYADD(graphic_add, cold_overlay)
-	else if (cold_overlay in graphic)
-		LAZYADD(graphic_remove, cold_overlay)
+		var/cold_overlay = get_tile_overlay(GAS_COLD)
+		if(temperature <= FOGGING_TEMPERATURE && (return_pressure() >= (ONE_ATMOSPHERE / 4)))
+			if(!(cold_overlay in graphic))
+				LAZYADD(graphic_add, cold_overlay)
+		else if (cold_overlay in graphic)
+			LAZYADD(graphic_remove, cold_overlay)
 
 	//Apply changes
 	if(graphic_add && length(graphic_add))
 		graphic |= graphic_add
-		. = 1
+		. = TRUE
+
 	if(graphic_remove && length(graphic_remove))
 		graphic -= graphic_remove
-		. = 1
-	if(length(graphic))
-		var/pressure_mod = clamp(return_pressure() / ONE_ATMOSPHERE, 0, 2)
-		for(var/obj/gas_overlay/O in graphic)
-			if(istype(O, /obj/gas_overlay/heat)) //Heat based
-				var/new_alpha = clamp(max(125, 255 * ((temperature - CARBON_LIFEFORM_FIRE_RESISTANCE) / CARBON_LIFEFORM_FIRE_RESISTANCE * 4)), 125, 255)
-				if(new_alpha != O.alpha)
-					O.update_alpha_animation(new_alpha)
-				continue
-			if(istype(O, /obj/gas_overlay/cold))
-				var/new_alpha = clamp(max(125, 200 * (1 - ((temperature - MAX_FOG_TEMPERATURE) / (FOGGING_TEMPERATURE - MAX_FOG_TEMPERATURE)))), 125, 200)
-				if(new_alpha != O.alpha)
-					O.update_alpha_animation(new_alpha)
-				continue
-			var/concentration_mod = clamp(gas[O.gas_id] / total_moles, 0.1, 1)
-			var/new_alpha = min(230, round(pressure_mod * concentration_mod * 180, 5))
-			if(new_alpha != O.alpha)
-				O.update_alpha_animation(new_alpha)
+		. = TRUE
+
+	if(!length(graphic))
+		return .
+
+	var/pressure_mod = clamp(return_pressure() / ONE_ATMOSPHERE, 0, 2)
+	for(var/obj/gas_overlay/overlay in graphic)
+		if(istype(overlay, /obj/gas_overlay/heat)) //Heat based
+			var/new_alpha = clamp(max(125, 255 * ((temperature - CARBON_LIFEFORM_FIRE_RESISTANCE) / CARBON_LIFEFORM_FIRE_RESISTANCE * 4)), 125, 255)
+			if(new_alpha != overlay.alpha)
+				overlay.update_alpha_animation(new_alpha)
+			continue
+
+		if(istype(overlay, /obj/gas_overlay/cold))
+			var/new_alpha = clamp(max(125, 200 * (1 - ((temperature - MAX_FOG_TEMPERATURE) / (FOGGING_TEMPERATURE - MAX_FOG_TEMPERATURE)))), 125, 200)
+			if(new_alpha != overlay.alpha)
+				overlay.update_alpha_animation(new_alpha)
+			continue
+
+		var/concentration_mod = clamp(gas[overlay.gas_id] / total_moles, 0.1, 1)
+		var/new_alpha = min(230, round(pressure_mod * concentration_mod * 180, 5))
+		if(new_alpha != overlay.alpha)
+			overlay.update_alpha_animation(new_alpha)
 
 /datum/gas_mixture/proc/get_tile_overlay(gas_id)
 	if(!LAZYACCESS(tile_overlay_cache, gas_id))


### PR DESCRIPTION
## Что этот PR делает

Проблема состояло в том, что вокруг сьеры. на 50000 турфов, шло обновление температурного оверлея, когда газа было около 0.001 моля на турф. 
Так же небольшой рефактор названий переменных.

## Почему это хорошо для игры

Убирает ужасные лагспайки при вызове `update_graphic` 50000 раз каждые 2 секунды

## Изображения изменений
Нет.

## Тестирование

Скомпилировал, проверил корректность обновления оверлеев, там где обновление должно происходить

## Changelog

:cl:
fix: Не обновляем на турфах температурный эффект, когда это не нужно
/:cl:

