### PR TITLE
Remove absence of multi-z sounds

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -77,6 +77,7 @@
 #include "code\__defines\shuttle.dm"
 #include "code\__defines\singletons.dm"
 #include "code\__defines\skills.dm"
+#include "code\__defines\sound.dm"
 #include "code\__defines\species.dm"
 #include "code\__defines\subsystem-priority.dm"
 #include "code\__defines\subsystems.dm"

--- a/code/__defines/sound.dm
+++ b/code/__defines/sound.dm
@@ -1,0 +1,64 @@
+//Sound environment defines. Reverb preset for sounds played in an area, see sound datum reference for more.
+#define GENERIC 0
+#define PADDED_CELL 1
+#define ROOM 2
+#define BATHROOM 3
+#define LIVINGROOM 4
+#define STONEROOM 5
+#define AUDITORIUM 6
+#define CONCERT_HALL 7
+#define CAVE 8
+#define ARENA 9
+#define HANGAR 10
+#define CARPETED_HALLWAY 11
+#define HALLWAY 12
+#define STONE_CORRIDOR 13
+#define ALLEY 14
+#define FOREST 15
+#define CITY 16
+#define MOUNTAINS 17
+#define QUARRY 18
+#define PLAIN 19
+#define PARKING_LOT 20
+#define SEWER_PIPE 21
+#define UNDERWATER 22
+#define DRUGGED 23
+#define DIZZY 24
+#define PSYCHOTIC 25
+
+#define STANDARD_STATION STONEROOM
+#define LARGE_ENCLOSED HANGAR
+#define SMALL_ENCLOSED BATHROOM
+#define TUNNEL_ENCLOSED CAVE
+#define LARGE_SOFTFLOOR CARPETED_HALLWAY
+#define MEDIUM_SOFTFLOOR LIVINGROOM
+#define SMALL_SOFTFLOOR ROOM
+#define ASTEROID CAVE
+#define SPACE UNDERWATER
+
+
+//Defines for echo list index positions.
+//ECHO_DIRECT and ECHO_ROOM are the only two that actually appear to do anything, and represent the dry and wet channels of the environment effects, respectively.
+//The rest of the defines are there primarily for the sake of completeness. It might be worth testing on EAX-enabled hardware, and on future BYOND versions (I've tested with 511, 512, and 513)
+#define ECHO_DIRECT 1
+#define ECHO_DIRECTHF 2
+#define ECHO_ROOM 3
+#define ECHO_ROOMHF 4
+#define ECHO_OBSTRUCTION 5
+#define ECHO_OBSTRUCTIONLFRATIO 6
+#define ECHO_OCCLUSION 7
+#define ECHO_OCCLUSIONLFRATIO 8
+#define ECHO_OCCLUSIONROOMRATIO 9
+#define ECHO_OCCLUSIONDIRECTRATIO 10
+#define ECHO_EXCLUSION 11
+#define ECHO_EXCLUSIONLFRATIO 12
+#define ECHO_OUTSIDEVOLUMEHF 13
+#define ECHO_DOPPLERFACTOR 14
+#define ECHO_ROLLOFFFACTOR 15
+#define ECHO_ROOMROLLOFFFACTOR 16
+#define ECHO_AIRABSORPTIONFACTOR 17
+#define ECHO_FLAGS 18
+
+//Defines for controlling how zsound sounds.
+#define ZSOUND_DRYLOSS_PER_Z -2000 //Affects what happens to the dry channel as the sound travels through z-levels
+#define ZSOUND_DISTANCE_PER_Z 2 //Affects the distance added to the sound per z-level travelled

--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -84,6 +84,7 @@ GLOBAL_DATUM_INIT(sound_player, /singleton/sound_player, new)
 	var/sound_id       // The associated sound id, used for cleanup
 	var/status = 0     // Paused, muted, running? Global for all listeners
 	var/listener_status// Paused, muted, running? Specific for the given listener.
+	var/base_volume    // Volume of sound before environment effects
 
 	var/datum/proximity_trigger/square/proxy_listener
 	var/list/can_be_heard_from
@@ -104,6 +105,7 @@ GLOBAL_DATUM_INIT(sound_player, /singleton/sound_player, new)
 	src.source      = source
 	src.sound       = sound
 	src.sound_id    = sound_id
+	base_volume = sound.volume
 
 	if(sound.repeat) // Non-looping sounds may not reserve a sound channel due to the risk of not hearing when someone forgets to stop the token
 		var/channel = GLOB.sound_player.PrivGetChannel(src) //Attempt to find a channel
@@ -128,9 +130,9 @@ GLOBAL_DATUM_INIT(sound_player, /singleton/sound_player, new)
 
 /datum/sound_token/proc/SetVolume(new_volume)
 	new_volume = clamp(new_volume, 0, 100)
-	if(sound.volume == new_volume)
+	if(base_volume == new_volume)
 		return
-	sound.volume = new_volume
+	base_volume = new_volume
 	PrivUpdateListeners()
 
 /datum/sound_token/proc/Mute()
@@ -230,6 +232,7 @@ GLOBAL_DATUM_INIT(sound_player, /singleton/sound_player, new)
 	else if(prefer_mute)
 		listener_status[listener] &= ~SOUND_MUTE
 
+	sound.volume = adjust_volume_for_hearer(base_volume, source_turf, listener)
 	sound.x = source_turf.x - listener_turf.x
 	sound.z = source_turf.y - listener_turf.y
 	sound.y = 1
@@ -243,6 +246,7 @@ GLOBAL_DATUM_INIT(sound_player, /singleton/sound_player, new)
 		PrivUpdateListener(listener)
 
 /datum/sound_token/proc/PrivUpdateListener(listener, update_sound = TRUE)
+	sound.volume = adjust_volume_for_hearer(base_volume, get_turf(source), listener)
 	sound.environment = PrivGetEnvironment(listener)
 	sound.status = status|listener_status[listener]
 	if(update_sound)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -1,41 +1,3 @@
-//Sound environment defines. Reverb preset for sounds played in an area, see sound datum reference for more.
-#define GENERIC 0
-#define PADDED_CELL 1
-#define ROOM 2
-#define BATHROOM 3
-#define LIVINGROOM 4
-#define STONEROOM 5
-#define AUDITORIUM 6
-#define CONCERT_HALL 7
-#define CAVE 8
-#define ARENA 9
-#define HANGAR 10
-#define CARPETED_HALLWAY 11
-#define HALLWAY 12
-#define STONE_CORRIDOR 13
-#define ALLEY 14
-#define FOREST 15
-#define CITY 16
-#define MOUNTAINS 17
-#define QUARRY 18
-#define PLAIN 19
-#define PARKING_LOT 20
-#define SEWER_PIPE 21
-#define UNDERWATER 22
-#define DRUGGED 23
-#define DIZZY 24
-#define PSYCHOTIC 25
-
-#define STANDARD_STATION STONEROOM
-#define LARGE_ENCLOSED HANGAR
-#define SMALL_ENCLOSED BATHROOM
-#define TUNNEL_ENCLOSED CAVE
-#define LARGE_SOFTFLOOR CARPETED_HALLWAY
-#define MEDIUM_SOFTFLOOR LIVINGROOM
-#define SMALL_SOFTFLOOR ROOM
-#define ASTEROID CAVE
-#define SPACE UNDERWATER
-
 GLOBAL_LIST_INIT(shatter_sound,list('sound/effects/Glassbr1.ogg','sound/effects/Glassbr2.ogg','sound/effects/Glassbr3.ogg'))
 GLOBAL_LIST_INIT(explosion_sound,list('sound/effects/Explosion1.ogg','sound/effects/Explosion2.ogg'))
 GLOBAL_LIST_INIT(spark_sound,list('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg','sound/effects/sparks4.ogg'))
@@ -55,32 +17,75 @@ GLOBAL_LIST_INIT(chop_sound,list('sound/weapons/chop1.ogg','sound/weapons/chop2.
 GLOBAL_LIST_INIT(glasscrack_sound,list('sound/effects/glass_crack1.ogg','sound/effects/glass_crack2.ogg','sound/effects/glass_crack3.ogg','sound/effects/glass_crack4.ogg'))
 GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'))
 
-/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, frequency, is_ambiance = 0)
-	if (isnull(soundin))
-		return
-	soundin = get_sfx(soundin) // same sound for everyone
 
+/proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, frequency, is_ambiance = 0,  ignore_walls = TRUE, zrange = 2, override_env, envdry, envwet)
 	if(isarea(source))
 		error("[source] is an area and is trying to make the sound: [soundin]")
 		return
+
+	soundin = get_sfx(soundin) // same sound for everyone
 	frequency = vary && isnull(frequency) ? get_rand_frequency() : frequency // Same frequency for everybody
+
 	var/turf/turf_source = get_turf(source)
+	var/maxdistance = (world.view + extrarange) * 2
 
  	// Looping through the player list has the added bonus of working for mobs inside containers
-	for (var/mob/M in GLOB.player_list)
+	var/list/listeners = GLOB.player_list
+	if(!ignore_walls) //these sounds don't carry through walls
+		listeners = listeners & hearers(maxdistance, turf_source)
+
+	for(var/P in listeners)
+		var/mob/M = P
 		if(!M || !M.client)
 			continue
-		if(get_dist(M, turf_source) <= (world.view + extrarange) * 2)
+
+		if(get_dist(M, turf_source) <= maxdistance)
 			var/turf/T = get_turf(M)
-			if(T && T.z == turf_source.z && (!is_ambiance || M.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))
-				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, extrarange)
+
+			if(T && (T.z == turf_source.z || (zrange && AreConnectedZLevels(T.z, turf_source.z) && abs(T.z - turf_source.z) <= zrange)) && (!is_ambiance || M.get_preference_value(/datum/client_preference/play_ambiance) == GLOB.PREF_YES))
+				M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, is_global, extrarange, override_env, envdry, envwet)
 
 var/global/const/FALLOFF_SOUNDS = 0.5
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, extrarange, wait = FALSE) // SS220 EDIT
-	if (isnull(soundin))
+//Applies mob-specific and environment specific adjustments to volume value given
+/proc/adjust_volume_for_hearer(volume, turf/turf_source, atom/listener)
+	if(ismob(listener))
+		var/mob/M = listener
+		if(M.ear_deaf)
+			return 0
+		volume *= M.get_sound_volume_multiplier()
+
+	var/turf/T = get_turf(listener)
+	if(!T)
 		return
-	if(!src.client || ear_deaf > 0)	return
+	var/datum/gas_mixture/hearer_env = T.return_air()
+	var/datum/gas_mixture/source_env = turf_source.return_air()
+
+	var/pressure_factor = 1.0
+	if (hearer_env && source_env)
+		var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
+		if (pressure < ONE_ATMOSPHERE)
+			pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
+	else //in space
+		pressure_factor = 0
+
+	if (get_dist(T, turf_source) <= 1)
+		pressure_factor = max(pressure_factor, 0.15)	//hearing through contact
+
+	volume *= pressure_factor
+
+	if(istype(T,/turf/simulated) && istype(turf_source,/turf/simulated))
+		var/turf/simulated/sim_source = turf_source
+		var/turf/simulated/sim_destination = T
+		if(sim_destination.zone != sim_source.zone)
+			volume -= 30
+
+	return volume
+
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, extrarange, override_env, envdry, envwet, wait = FALSE)
+	if(!src.client || ear_deaf > 0)
+		return
+
 	var/sound/S = soundin
 	if(!istype(S))
 		soundin = get_sfx(soundin)
@@ -94,34 +99,16 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 		else if (vary)
 			S.frequency = get_rand_frequency()
 
-	//sound volume falloff with pressure
-	var/pressure_factor = 1.0
-
-	S.volume *= get_sound_volume_multiplier()
-
 	var/turf/T = get_turf(src)
+	S.volume = adjust_volume_for_hearer(S.volume, turf_source, src)
+
 	// 3D sounds, the technology is here!
+
 	if(isturf(turf_source))
 		//sound volume falloff with distance
 		var/distance = get_dist(T, turf_source)
 
 		S.volume -= max(distance - (world.view + extrarange), 0) * 2 //multiplicative falloff to add on top of natural audio falloff.
-
-		var/datum/gas_mixture/hearer_env = T.return_air()
-		var/datum/gas_mixture/source_env = turf_source.return_air()
-
-		if (hearer_env && source_env)
-			var/pressure = min(hearer_env.return_pressure(), source_env.return_pressure())
-
-			if (pressure < ONE_ATMOSPHERE)
-				pressure_factor = max((pressure - SOUND_MINIMUM_PRESSURE)/(ONE_ATMOSPHERE - SOUND_MINIMUM_PRESSURE), 0)
-		else //in space
-			pressure_factor = 0
-
-		if (distance <= 1)
-			pressure_factor = max(pressure_factor, 0.15)	//hearing through contact
-
-		S.volume *= pressure_factor
 
 		if (S.volume <= 0)
 			return	//no volume means no sound
@@ -130,9 +117,12 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 		S.x = dx
 		var/dz = turf_source.y - T.y // Hearing from infront/behind
 		S.z = dz
-		// The y value is for above your head, but there is no ceiling in 2d spessmens.
-		S.y = 1
+		var/dy = (turf_source.z - T.z) * ZSOUND_DISTANCE_PER_Z // Hearing from above/below. There is ceiling in 2d spessmans.
+		S.y = (dy < 0) ? dy - 1 : dy + 1 //We want to make sure there's *always* at least one extra unit of distance. This helps normalize sound that's emitting from the turf you're on.
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
+
+		if(!override_env)
+			envdry = abs(turf_source.z - T.z) * ZSOUND_DRYLOSS_PER_Z
 
 	if(!is_global)
 
@@ -150,17 +140,17 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 				S.environment = UNDERWATER
 			else if (T?.is_flooded(M.lying))
 				S.environment = UNDERWATER
-			else if (pressure_factor < 0.5)
-				S.environment = SPACE
 			else
 				var/area/A = get_area(src)
 				S.environment = A.sound_env
-
-		else if (pressure_factor < 0.5)
-			S.environment = SPACE
 		else
 			var/area/A = get_area(src)
 			S.environment = A.sound_env
+
+	var/list/echo_list = new(18)
+	echo_list[ECHO_DIRECT] = envdry
+	echo_list[ECHO_ROOM] = envwet
+	S.echo = echo_list
 
 	sound_to(src, S)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -74,7 +74,8 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 
 	volume *= pressure_factor
 
-	if(istype(T,/turf/simulated) && istype(turf_source,/turf/simulated))
+	//Dense turfs are not in the zones, so they shouldn't be penalized here when source
+	if(!turf_source.blocks_air && istype(T,/turf/simulated) && istype(turf_source,/turf/simulated))
 		var/turf/simulated/sim_source = turf_source
 		var/turf/simulated/sim_destination = T
 		if(sim_destination.zone != sim_source.zone)
@@ -100,7 +101,8 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 			S.frequency = get_rand_frequency()
 
 	var/turf/T = get_turf(src)
-	S.volume = adjust_volume_for_hearer(S.volume, turf_source, src)
+	if(!is_global)
+		S.volume = adjust_volume_for_hearer(S.volume, turf_source, src)
 
 	// 3D sounds, the technology is here!
 

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -11,6 +11,7 @@
 		material = SSmaterials.get_material_by_name(DEFAULT_WALL_MATERIAL)
 	if(material)
 		explosion_resistance = material.explosion_resistance
+		hitsound = material.hitsound
 	if(reinf_material && reinf_material.explosion_resistance > explosion_resistance)
 		explosion_resistance = reinf_material.explosion_resistance
 	// Base material `explosion_resistance` is `5`, so a value of `5 `should result in a wall resist value of `1`.


### PR DESCRIPTION
Добавляет межуровневый звук. 

Этот эффект можно настроить с помощью параметров ZSOUND_DRYLOSS_PER_Z и ZSOUND_DISTANCE_PER_Z в файле code/__defines/sound.dm. Первое влияет на то, насколько глуше становится звук, если расстояние между z-уровнями больше, а второе - на то, сколько физического расстояния добавляется на каждый z-уровень. Параметры по умолчанию настроены таким образом, чтобы сделать тихие звуки почти неслышными, но при этом позволить более сильным звукам (например, выстрелам и атакам ближнего боя) распространяться по всему кораблю/станции/и т.д.

Поведение звука также можно изменить с помощью новых аргументов playsound и playsound_local. Для первого из них добавлены следующие параметры: zrange (влияет на количество уровней z вверх и вниз, по умолчанию 2), override_env (отключает эффекты zsound для лучшего ручного управления звуками), envdry (влияет на "сухой" канал (ECHO_DIRECT), именно его zsound регулирует для придания эффекта приглушенности, envwet (влияет на канал (ECHO_ROOM). Для последнего добавляются следующие параметры: override_env, envdry и envwet.

:cl:
experiment: Добавил эксперементальный режим работы звука
/:cl:
