### PR TITLE
Remove lack of airlock speed

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -9,7 +9,7 @@
 #define TARGET_INOPEN		-1
 #define TARGET_OUTOPEN		-2
 
-#define SENSOR_TOLERANCE 1
+#define SENSOR_TOLERANCE 0.5
 
 /datum/computer/file/embedded_program/airlock
 	var/tag_exterior_door
@@ -221,7 +221,7 @@
 						signalPump(tag_airpump, 1, 0, target_pressure)	//send a signal to start depressurizing
 					else
 						signalPump(tag_pump_out_internal, 1, 0, target_pressure) // if going inside, pump external air out of the airlock
-						signalPump(tag_pump_out_external, 1, 1, 1000) // make sure the air is actually going outside
+						signalPump(tag_pump_out_external, 1, 1, MAX_PUMP_PRESSURE) // make sure the air is actually going outside
 
 				else if(chamber_pressure <= target_pressure)
 					state = STATE_PRESSURIZE


### PR DESCRIPTION
Изменяет tolerance аирлока до 0,5 - самое низкое число, которое не приводило к замедлению его цикла. Это должно уменьшить количество утечек воздуха из шлюзов, работающих по циклу с внешней средой.
Изменено целевое внешнее давление для внешних шлюзов с 1000 на MAX_PUMP_PRESSURE, для ускорения циклинга на вулканических планетах с очень высоким давлением. К сожалению, некоторые планеты все еще могут генерировать давление, превышающее это значение.
## Changelog

:cl:
tweak: Ускорил работу шлюзов
/:cl: