### PR TITLE
fix: fix runechat style

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -182,9 +182,10 @@ window "mapwindow"
 		font-size = 7
 		is-default = true
 		saved-params = "icon-size"
-		style = ".maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; }"
+		style = ".maptext { font-family: 'MS Serif'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; }"
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
+		style=".center { text-align: center; } .maptext { font-family: 'MS Serif'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .small { font-size: 6px; } .big { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .yell { font-weight: bold; } .emote { font-size: 6px; } .italics { font-size: 6px; font-style: italic; }"
 	elem "lobbybrowser"
 		type = BROWSER
 		pos = 0,0


### PR DESCRIPTION
## Что этот PR делает

У рунчата правильные стили и шрифт (MS Serif), поддерживающий специфические для кириллицы буквы шрифт

## Почему это хорошо для игры

UI/UX

## Изображения изменений
<details>
<summary>Скриншоты</summary>
![image](https://github.com/ss220club/WyccerraBay220/assets/44334376/e0197ce3-7cf6-4648-8038-d9a9eea0c018)

</details>

## Тестирование

Компилится, результат на скрине.

## Changelog

:cl:
fix: Runechat снова имеет правильные стили
/:cl:
 
