### PR TITLE
fix: don't iterate world

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -215,15 +215,18 @@
 /obj/machinery/conveyor_switch/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))
 		return FALSE
+
 	do_switch()
-	operated = 1
+	operated = TRUE
 	update_icon()
 
 	// find any switches with same id as this one, and set their positions to match us
-	for(var/obj/machinery/conveyor_switch/S in world)
-		if(S.id == src.id)
-			S.position = position
-			S.update_icon()
+	for(var/obj/machinery/conveyor_switch/other_switch as anything in SSmachines.get_machinery_of_type(/obj/machinery/conveyor_switch))
+		if(other_switch.id != id)
+			continue
+
+		other_switch.position = position
+		other_switch.update_icon()
 	return TRUE
 
 /obj/machinery/conveyor_switch/proc/do_switch(mob/user)


### PR DESCRIPTION

## Что этот PR делает

Убираем `in world` где он не нужен

## Почему это хорошо для игры

Меньше лагспайков - лучше

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

Компилируется, не рантаймит

## Changelog

:cl:
fix: Не перебираем все рычаги в мире при нажатии на один. Меньше лагов
/:cl:

