### PR TITLE
Fixes grab-self

### DIFF
--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -277,7 +277,7 @@
 	var/extra_delay = 0
 	for (var/obj/item/grab/G in mob)
 		if(G.assailant == G.affecting)
-			return
+			continue
 		extra_delay = max(extra_delay, G.grab_slowdown())
 
 	mob.ExtraMoveCooldown(extra_delay)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Убирает ретурн в муве, когда моб уже по факту начал движение и не должен ретурниться.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Можно грабать себя и ломать себе конечности без проблем для ног.

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Грабнул себя, вывехнул себе руку, я могу ходить.

## Changelog

:cl:
fix: Граб по себе больше не ломает движение. Можно выворачивать себе руки и все еще иметь ноги!
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
