### PR TITLE
Mechs can activate modules without selecting it

### DIFF
--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -72,11 +72,12 @@
 		return
 
 	if(modifiers["ctrl"])
-		for(var/hardpoint in hardpoints)
-			if(A == hardpoints[hardpoint])
-				A.CtrlClick(user)
-				setClickCooldown(3)
-				return
+		if(istype(A, /obj/item/mech_equipment))
+			for(var/hardpoint in hardpoints)
+				if(A == hardpoints[hardpoint])
+					A.CtrlClick(user)
+					setClickCooldown(3)
+					return
 
 	if(!(user in pilots) && user != src)
 		return
@@ -121,12 +122,13 @@
 		failed = TRUE
 
 	if(!failed)
-		for(var/hardpoint in hardpoints)
-			if(A == hardpoints[hardpoint])
-				var/obj/item/mech_equipment/mech_equipment = A
-				mech_equipment.attack_self(user)
-				setClickCooldown(5)
-				return
+		if(istype(A, /obj/item/mech_equipment))
+			for(var/hardpoint in hardpoints)
+				if(A == hardpoints[hardpoint])
+					var/obj/item/mech_equipment/mech_equipment = A
+					mech_equipment.attack_self(user)
+					setClickCooldown(5)
+					return
 		if(selected_system)
 			// Mounted non-exosuit systems have some hacky loc juggling
 			// to make sure that they work.

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -72,11 +72,11 @@
 		return
 
 	if(modifiers["ctrl"])
-		if(selected_system)
-			if(selected_system == A)
-				selected_system.CtrlClick(user)
+		for(var/hardpoint in hardpoints)
+			if(A == hardpoints[hardpoint])
+				A.CtrlClick(user)
 				setClickCooldown(3)
-			return
+				return
 
 	if(!(user in pilots) && user != src)
 		return
@@ -121,12 +121,13 @@
 		failed = TRUE
 
 	if(!failed)
-		if(selected_system)
-			if(selected_system == A)
-				selected_system.attack_self(user)
+		for(var/hardpoint in hardpoints)
+			if(A == hardpoints[hardpoint])
+				var/obj/item/mech_equipment/mech_equipment = A
+				mech_equipment.attack_self(user)
 				setClickCooldown(5)
 				return
-
+		if(selected_system)
 			// Mounted non-exosuit systems have some hacky loc juggling
 			// to make sure that they work.
 			var/system_moved = FALSE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Теперь для активации модуля (attack_self) можно просто по нему тыкнуть, а не сначала выбрать, а потом тыкнуть.

Выглядит упорото, но иначе нужно будет полностью рефакторить логику тыков по хардпоинтам/модулям/пространству. Задача на будущее.

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Делает использование более юзер френдли

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Зашел в меха, выбрал карабин, тыкнул в фонарик и флеш, фонарик и флеш работают без выбора.

## Changelog

:cl:
tweak: Мехи могут использовать модули без необходимости выбора (особенно полезно для тех, которые выбирать нет смысла)
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
