### PR TITLE
Fixes length to length_char in tgui text input

### DIFF
--- a/code/modules/tgui/tgui_input/text_input.dm
+++ b/code/modules/tgui/tgui_input/text_input.dm
@@ -144,9 +144,9 @@
 		if("submit")
 			if(!max_length)
 				return
-			if(length(params["entry"]) > max_length)
+			if(length_char(params["entry"]) > max_length)
 				CRASH("[usr] typed a text string longer than the max length")
-			if(encode && (length(html_encode(params["entry"])) > max_length))
+			if(encode && (length_char(html_encode(params["entry"])) > max_length))
 				to_chat(usr, "<span class='notice'>Your message was clipped due to special character usage.</span>")
 			set_entry(params["entry"])
 			closed = TRUE


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Позволяет использовать кириллицу корректно в текст инпуте (проверка на длину текста)

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Создал куклу с именем "Проверка Проверка Проверка" (которая не создавалась без фикса)
Зашел в раунд - имя сохранилось

## Changelog

:cl:
fix: Теперь можно ставить имена в длину 26 на кириллице
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
