### PR TITLE
A* only on target

### DIFF
--- a/code/modules/ai/ai_holder_movement.dm
+++ b/code/modules/ai/ai_holder_movement.dm
@@ -114,7 +114,7 @@
 /datum/ai_holder/proc/walk_path(atom/A, get_to = 1)
 	ai_log("walk_path() : Entering.", AI_LOG_TRACE)
 
-	if (use_astar)
+	if (use_astar && target)
 		if (!length(path)) // If we're missing a path, make a new one.
 			ai_log("walk_path() : No path. Attempting to calculate path.", AI_LOG_DEBUG)
 			calculate_path(A, get_to)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Теперь продвинутый алгоритм поиска пути будет работать только когда есть "цель" у моба. 

## Почему это хорошо для игры
Меньше лагов


## Тестирование
тест на зомби на локалке 

## Changelog

:cl:
tweak: A* only on target
/:cl:
