### PR TITLE
fix: return back preview toggles

### DIFF
--- a/code/modules/client/preference_setup/general/05_preview.dm
+++ b/code/modules/client/preference_setup/general/05_preview.dm
@@ -234,7 +234,7 @@
 	. += "<br>[BTN("previewgear", "[pref.preview_gear ? "Hide" : "Show"] Loadout")]"
 	. += " - [BTN("job_preview", "[pref.preview_job ? "Hide" : "Show"] Uniform")]"
 	. += "<br>"
-	. = "<b>Preview Background:</b><br>"
+	. += "<b>Preview Background:</b><br>"
 	for(var/background_name in pref.character_preview_backgrounds)
 		. += VCBTN( \
 			"set_preview_background", \


### PR DESCRIPTION
## Что этот PR делает

Возвращает preview toggles

## Почему это хорошо для игры

Багов не должно быть

## Изображения изменений
<details>
<summary>Скриншоты</summary>

![image](https://github.com/ss220club/WyccerraBay220/assets/44334376/02380746-43e5-4b09-9863-a3c7f02a9c45)

</details>

## Тестирование

Скомпилил, на скрине видно кнопки.

## Changelog

:cl:
fix: Вернул preview toggles
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
