### PR TITLE
fix: you can change underware again

### DIFF
--- a/code/datums/category.dm
+++ b/code/datums/category.dm
@@ -47,7 +47,7 @@
 
 		var/datum/category_item/item = new item_type(src)
 		LAZYADD(items, item)
-		LAZYADDASSOC(items_by_name, item.name, item)
+		LAZYSET(items_by_name, item.name, item)
 
 	// For whatever reason dd_insertObjectList(items, item) doesn't insert in the correct order
 	// If you change this, confirm that character setup doesn't become completely unordered.

--- a/code/datums/underwear/underwear.dm
+++ b/code/datums/underwear/underwear.dm
@@ -13,6 +13,13 @@
 /datum/category_group/underwear/dd_SortValue()
 	return sort_order
 
+/datum/category_group/underwear/proc/get_default_category_item(gender)
+	for(var/datum/category_item/underwear/underwear_category_item as anything in items)
+		if(underwear_category_item.is_default(gender))
+			return underwear_category_item
+
+	return null
+
 /datum/category_group/underwear/top
 	name = "Underwear, top"
 	sort_order = 1


### PR DESCRIPTION
## Что этот PR делает

Возвращение блудных трусов. Теперь можно выбирать трусы опять

## Почему это хорошо для игры

Не все любят стандартные трусы

## Тестирование

Компилится, трусы меняются, персонаж сохраняется. Рантаймов нет

## Changelog

:cl:
fix: Трусы снова меняются на персонаже в настройках персонажа
/:cl:
