### PR TITLE
fix: most of widescreen issues fixes. Make documents loadout free

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -597,3 +597,11 @@
 /proc/get_view_size_y(view)
 	var/list/view_size = getviewsize(view)
 	return view_size[2]
+
+/proc/get_lesser_view_size_component(view)
+	var/list/view_size = getviewsize(view)
+	return min(view_size[1], view_size[2])
+
+/proc/get_greater_view_size_component(view)
+	var/list/view_size = getviewsize(view)
+	return max(view_size[1], view_size[2])

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -176,9 +176,9 @@
 		to_chat(usr, SPAN_WARNING("Inventory hiding is currently only supported for human mobs, sorry."))
 		return
 
-	if(!client) return
-	if(client.view != world.view)
+	if(!client)
 		return
+
 	if(hud_used.hud_shown)
 		hud_used.hud_shown = 0
 		if(src.hud_used.adding)
@@ -232,8 +232,6 @@
 	if(!ishuman(src))
 		return
 	if(!client)
-		return
-	if(client.view != world.view)
 		return
 
 	if(hud_used.hud_shown)

--- a/code/_onclick/hud/movable_screen_objects.dm
+++ b/code/_onclick/hud/movable_screen_objects.dm
@@ -79,7 +79,7 @@
 		. = "CENTER"
 
 /obj/screen/movable/proc/decode_screen_Y(Y, mob/viewer)
-	var/view = viewer.client ? get_view_size_x(viewer.client.view) : world.view
+	var/view = viewer.client ? get_view_size_y(viewer.client.view) : world.view
 	if(findtext(Y,"NORTH-"))
 		var/num = text2num(copytext(Y,7)) //Trim NORTH-
 		if(!num)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -825,7 +825,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if(!user.client)
 		return
 
-	user.client.view = world.view
+	user.client.view = user.get_preference_value(/datum/client_preference/client_view)
 	if(!user.hud_used.hud_shown)
 		user.toggle_zoom_hud()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -799,7 +799,7 @@ Ccomp's first proc.
 	if(view == world.view)
 		view = input("Select view range:", "FUCK YE", 7) in list(1,2,3,4,5,6,7,8,9,10,11,12,13,14,128)
 	else
-		view = world.view
+		view = get_preference_value(/datum/client_preference/client_view)
 
 	log_and_message_admins("changed their view range to [view].")
 

--- a/code/modules/client/preference_setup/loadout/lists/documents.dm
+++ b/code/modules/client/preference_setup/loadout/lists/documents.dm
@@ -24,8 +24,10 @@
 	display_name = "work visa"
 	description = "A work visa issued by the Sol Central Government for the purpose of work."
 	path = /obj/item/paper/workvisa
+	cost = 0
 
 /datum/gear/document/travelvisa
 	display_name = "travel visa"
 	description = "A travel visa issued by the Sol Central Government for the purpose of recreation."
 	path = /obj/item/paper/travelvisa
+	cost = 0

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -71,6 +71,7 @@
 
 	maybe_send_staffwarns("joined the round")
 
+	client.view = get_preference_value(/datum/client_preference/client_view)
 	client.images = null				//remove the images such as AIs being unable to see runes
 	client.screen = list()				//remove hud items just in case
 	InitializeHud()

--- a/code/modules/nano/interaction/default.dm
+++ b/code/modules/nano/interaction/default.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 	if(can_admin_interact())
 		return STATUS_INTERACTIVE							// Admins are more equal
 
-	if(!client || get_dist(src_object, src)	> get_view_size_x(client.view))	// Preventing ghosts from having a million windows open by limiting to objects in range
+	if(!client || get_dist(src_object, src)	> get_lesser_view_size_component(client.view))	// Preventing ghosts from having a million windows open by limiting to objects in range
 		return STATUS_CLOSE
 	return STATUS_UPDATE									// Ghosts can view updates
 
@@ -29,7 +29,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 		return
 
 	// robots can interact with things they can see within their view range
-	if(get_dist(src_object, src) <= get_view_size_x(client.view) && (src_object in view(src)))
+	if(get_dist(src_object, src) <= get_lesser_view_size_component(client.view) && (src_object in view(src)))
 		return STATUS_INTERACTIVE	// interactive (green visibility)
 	return STATUS_DISABLED			// no updates, completely disabled (red visibility)
 
@@ -55,7 +55,7 @@ GLOBAL_DATUM_INIT(default_state, /datum/topic_state/default, new)
 		if(cameranet && !cameranet.is_turf_visible(get_turf(src_object)))
 			return STATUS_CLOSE
 		return STATUS_INTERACTIVE
-	else if(get_dist(src_object, src) <= get_view_size_x(client.view))	// View does not return what one would expect while installed in an inteliCard
+	else if(get_dist(src_object, src) <= get_lesser_view_size_component(client.view))	// View does not return what one would expect while installed in an inteliCard
 		return STATUS_INTERACTIVE
 
 	return STATUS_CLOSE

--- a/code/modules/overmap/ships/computers/ship.dm
+++ b/code/modules/overmap/ships/computers/ship.dm
@@ -82,7 +82,7 @@ somewhere on that shuttle. Subtypes of these can be then used to perform ship ov
 /obj/machinery/computer/ship/proc/unlook(mob/user)
 	user.reset_view(null, FALSE)
 	if(user.client)
-		user.client.view = world.view
+		user.client.view = user.get_preference_value(/datum/client_preference/client_view)
 	if(linked)
 		for(var/obj/machinery/shipsensors/sensor in linked.sensors)
 			sensor.hide_contacts(user)

--- a/code/modules/tgui/states.dm
+++ b/code/modules/tgui/states.dm
@@ -26,8 +26,7 @@
 
 		// Regular ghosts can always at least view if in range.
 		if(user.client)
-			var/clientviewlist = getviewsize(user.client.view)
-			if(get_dist(src_object, user) < max(clientviewlist[1], clientviewlist[2]))
+			if(get_dist(src_object, user) < get_greater_view_size_component(user.client.view))
 				. = max(., STATUS_UPDATE)
 
 	// Check if the state allows interaction

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -30,8 +30,7 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 		return
 
 	// Robots can interact with anything they can see.
-	var/list/clientviewlist = getviewsize(client.view)
-	if((src_object in view(src)) && (get_dist(src, src_object) <= min(clientviewlist[1],clientviewlist[2])))
+	if((src_object in view(src)) && (get_dist(src, src_object) <= get_lesser_view_size_component(client.view)))
 		return STATUS_INTERACTIVE
 	return STATUS_DISABLED // Otherwise they can keep the UI open.
 
@@ -46,7 +45,7 @@ GLOBAL_DATUM_INIT(tgui_default_state, /datum/tgui_state/default, new)
 		if(is_in_chassis())
 			can_see = cameranet && cameranet.is_turf_visible(get_turf(src_object))
 		else
-			can_see = get_dist(src_object, src) <= client.view
+			can_see = get_dist(src_object, src) <= get_lesser_view_size_component(client.view)
 
 	if(!control_disabled && can_see)
 		return STATUS_INTERACTIVE


### PR DESCRIPTION
## Что этот PR делает

Исправляем проблемы с вайдскрином. Теперь он корректно обновляется после бинокля, консоли и тд

## Почему это хорошо для игры

Не будет необходимости каждый раз тыкать настройку, дабы получить вайдскрин обратно

## Тестирование

Компилится, рантаймов нет, вайдскрин работает как надо

## Changelog

:cl:
fix: Исправил проблемы с вайдскрином
/:cl:

