### PR TITLE
add toggle safety signal, use it for underslung launcher

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -100,6 +100,7 @@
 #include "code\__defines\dcs\signals\signals_atom_movable.dm"
 #include "code\__defines\dcs\signals\signals_datum.dm"
 #include "code\__defines\dcs\signals\signals_mob.dm"
+#include "code\__defines\dcs\signals\signals_object.dm"
 #include "code\__defines\~mods\bloom_light.dm"
 #include "code\__defines\~mods\expanded_culture_descriptor.dm"
 #include "code\__defines\~mods\rust_g.dm"

--- a/code/__defines/dcs/signals/signals_object.dm
+++ b/code/__defines/dcs/signals/signals_object.dm
@@ -1,0 +1,2 @@
+/// from base of /obj/item/gun/toggle_safety(): (safety_state)
+#define COMSIG_GUN_TOGGLE_SAFETY "gun_toggle_safety"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -667,6 +667,7 @@
 		user.visible_message(SPAN_WARNING("[user] switches the safety of \the [src] [safety_state ? "on" : "off"]."), SPAN_NOTICE("You switch the safety of \the [src] [safety_state ? "on" : "off"]."), range = 3)
 		last_safety_check = world.time
 		playsound(src, 'sound/weapons/flipblade.ogg', 15, 1)
+	SEND_SIGNAL(src, COMSIG_GUN_TOGGLE_SAFETY, safety_state)
 
 /obj/item/gun/verb/toggle_safety_verb()
 	set src in usr

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -129,13 +129,22 @@
 		grenade_type = pickweight(grenade_types)
 		grenades += new grenade_type(src)
 
-//Underslung grenade launcher to be used with the Z8
 /obj/item/gun/launcher/grenade/underslung
 	name = "underslung grenade launcher"
 	desc = "Not much more than a tube and a firing mechanism, this grenade launcher is designed to be fitted to a rifle."
 	w_class = ITEM_SIZE_NORMAL
 	force = 5
 	max_grenades = 0
+
+/obj/item/gun/launcher/grenade/underslung/Initialize()
+	. = ..()
+	if(istype(loc, /obj/item/gun))
+		RegisterSignal(loc, COMSIG_GUN_TOGGLE_SAFETY, PROC_REF(update_safety))
+
+/obj/item/gun/launcher/grenade/underslung/proc/update_safety(obj/item/gun/parent, safety_state)
+	SIGNAL_HANDLER
+	src.safety_state = safety_state
+	update_icon()
 
 /obj/item/gun/launcher/grenade/underslung/attack_self()
 	return

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -219,11 +219,6 @@
 
 	return ..()
 
-/obj/item/gun/projectile/automatic/bullpup_rifle/toggle_safety(mob/user)
-	..()
-	if(launcher)
-		launcher.safety_state = safety_state //Set the launcher's safety to be equivalent to the bullpup's.
-
 /obj/item/gun/projectile/automatic/bullpup_rifle/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && launcher && use_launcher)
 		launcher.unload(user)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Добавляет сигнал для `proc/toggle_safety`
Использует сигнал для переключения сейфити у underslung launcher

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Фиксит переключение сейфити

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Пострелял с буллпапа, выстрелил гранатой
Пострелял с лазгана, выстрелил гранатой

## Changelog

:cl:
fix: Теперь bonfire лазган может стрелять из подствольного гранатомета
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
