### PR TITLE
tweak: add ability to disable roundstart vote, make `secret` master gamemode

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -102,6 +102,9 @@
 	/// Length of time before round start (in seconds)
 	var/static/pre_game_time = 180
 
+	/// If we want to bypass gamemode vote
+	var/static/bypass_gamemode_vote = FALSE
+
 	/// vote does not default to nochange/norestart (tbi)
 	var/static/vote_no_default = FALSE
 
@@ -634,6 +637,8 @@
 				vote_autogamemode_timeleft = text2num(value)
 			if ("pre_game_time")
 				pre_game_time = text2num(value)
+			if ("bypass_gamemode_vote")
+				bypass_gamemode_vote = TRUE
 			if ("ert_admin_only")
 				ert_admin_call_only = TRUE
 			if ("respawn_delay")

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -9,9 +9,9 @@ SUBSYSTEM_DEF(ticker)
 	var/pregame_timeleft
 	var/start_ASAP = FALSE          //the game will start as soon as possible, bypassing all pre-game nonsense
 	var/list/gamemode_vote_results  //Will be a list, in order of preference, of form list(config_tag = number of votes).
-	var/bypass_gamemode_vote = 0    //Intended for use with admin tools. Will avoid voting and ignore any results.
+	var/bypass_gamemode_vote = TRUE    //Intended for use with admin tools. Will avoid voting and ignore any results.
 
-	var/master_mode = "extended"    //The underlying game mode (so "secret" or the voted mode). Saved to default back to previous round's mode in case the vote failed. This is a config_tag.
+	var/master_mode = "secret"    //The underlying game mode (so "secret" or the voted mode). Saved to default back to previous round's mode in case the vote failed. This is a config_tag.
 	var/datum/game_mode/mode        //The actual gamemode, if selected.
 	var/round_progressing = 1       //Whether the lobby clock is ticking down.
 
@@ -50,6 +50,7 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/Initialize(start_uptime)
 	pregame_timeleft = config.pre_game_time SECONDS
+	bypass_gamemode_vote = config.bypass_gamemode_vote
 	build_mode_cache()
 	to_world(SPAN_INFO("<B>Welcome to the pre-game lobby!</B>"))
 	to_world("Please, setup your character and select ready. Game will start in [round(pregame_timeleft/10)] seconds")
@@ -112,8 +113,10 @@ SUBSYSTEM_DEF(ticker)
 	if(start_ASAP)
 		start_now()
 		return
+
 	if(round_progressing && last_fire)
 		pregame_timeleft -= world.time - last_fire
+
 	if(pregame_timeleft <= 0)
 		Master.SetRunLevel(RUNLEVEL_SETUP)
 		return
@@ -570,9 +573,9 @@ Helpers
 		return
 	if(istype(SSvote.active_vote, /datum/vote/gamemode))
 		SSvote.cancel_vote(user)
-		bypass_gamemode_vote = 1
+		bypass_gamemode_vote = TRUE
 	Master.SetRunLevel(RUNLEVEL_SETUP)
-	return 1
+	return TRUE
 
 
 /hook/roundstart/proc/PlayWelcomeSound()

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -985,7 +985,7 @@
 		if (SSticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)
 		SSticker.master_mode = href_list["c_mode2"]
-		SSticker.bypass_gamemode_vote = 1
+		SSticker.bypass_gamemode_vote = TRUE
 		log_and_message_admins("set the mode as [SSticker.master_mode].")
 		to_world(SPAN_NOTICE("<b>The mode is now: [SSticker.master_mode]</b>"))
 		Game() // updates the main game menu

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -161,6 +161,9 @@ VOTE_AUTOGAMEMODE_TIMELEFT 160
 # Should be bigger than VOTE_AUTOGAMEMODE_TIMELEFT + VOTE_PERIOD.
 PRE_GAME_TIME 180
 
+## If we want to bypass gamemode vote
+BYPASS_GAMEMODE_VOTE
+
 ## prevents dead players from voting or starting votes
 #NO_DEAD_VOTE
 


### PR DESCRIPTION

## Что этот PR делает

Добавляем возможность отключить голосование за гейммод. Ставим сикрет по-умолчанию

## Почему это хорошо для игры

1984

## Тестирование

Компилится, работает. Режим выбирается корректно
