### PR TITLE
refactor: make xenoarch initialize for not an eternity

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -267,6 +267,7 @@
 #include "code\controllers\subsystems\initialization\persistence.dm"
 #include "code\controllers\subsystems\initialization\robots.dm"
 #include "code\controllers\subsystems\initialization\webhooks.dm"
+#include "code\controllers\subsystems\initialization\xenoarch.dm"
 #include "code\controllers\subsystems\processing\circuit.dm"
 #include "code\controllers\subsystems\processing\disposals.dm"
 #include "code\controllers\subsystems\processing\fast_process.dm"

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -237,14 +237,19 @@ Checks if a list has the same entries and values as an element of big.
 		return len
 	return null
 
-//Pick a random element from the list and remove it from the list.
-/proc/pick_n_take(list/listfrom)
-	if (length(listfrom) > 0)
-		var/picked = pick(listfrom)
-		listfrom -= picked
-		return picked
-	return null
+/// Pick a random element from the list and remove it from the list.
+/proc/pick_n_take(list/list_to_pick)
+	RETURN_TYPE(list_to_pick[_].type)
 
+	var/list_length = length(list_to_pick)
+	if(!list_length)
+		return null
+
+	var/picked_index = rand(1, list_length)
+	var/picked = list_to_pick[picked_index]
+	list_to_pick.Cut(picked_index, picked_index + 1)
+
+	return picked
 
 /// Remove and return the last element of the list, or null.
 /proc/pop(list/list)

--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -14,8 +14,6 @@ SUBSYSTEM_DEF(init_misc_late)
 	GLOB.using_map.build_away_sites()
 	GLOB.using_map.build_exoplanets()
 	init_recipes()
-	init_xenoarch()
-
 
 GLOBAL_VAR_INIT(microwave_maximum_item_storage, 0)
 GLOBAL_LIST_EMPTY(microwave_recipes)
@@ -52,91 +50,3 @@ GLOBAL_LIST_EMPTY(microwave_accepts_items)
 
 /proc/cmp_microwave_recipes_by_weight_dsc(datum/microwave_recipe/a, datum/microwave_recipe/b)
 	return a.weight - b.weight
-
-
-GLOBAL_LIST_EMPTY(xeno_artifact_turfs)
-GLOBAL_LIST_EMPTY(xeno_digsite_turfs)
-
-/datum/controller/subsystem/init_misc_late/proc/init_xenoarch()
-	var/list/queue = list()
-	var/list/site_turfs = list()
-	var/list/artifact_turfs = list()
-	var/datum/map/map = GLOB.using_map
-	if (!map)
-		GLOB.xeno_artifact_turfs = list()
-		GLOB.xeno_digsite_turfs = list()
-		return
-	var/list/banned_levels = map.admin_levels + map.escape_levels
-	for (var/turf/simulated/mineral/M in world)
-		if (!M.density)
-			continue
-		if (M.z in banned_levels)
-			continue
-		if (!M.geologic_data)
-			M.geologic_data = new (M)
-		if (!prob(0.5))
-			continue
-		var/has_space = TRUE
-		for (var/turf/T as anything in site_turfs)
-			if (T.z != M.z)
-				continue
-			if (abs(T.x - M.x) > 3)
-				continue
-			if (abs(T.y - M.y) > 3)
-				continue
-			has_space = FALSE
-			break
-		if (!has_space)
-			continue
-		site_turfs += M
-		queue.Cut()
-		queue += M
-		for (var/turf/simulated/mineral/T in orange(2, M))
-			if (!T.density)
-				continue
-			if (T.finds)
-				continue
-			queue += T
-		var/site_turf_count = rand(4, 12)
-		if (site_turf_count < length(queue))
-			for (var/i = length(queue) - site_turf_count to 1 step -1)
-				var/selected = rand(1, length(queue))
-				queue.Cut(selected, selected + 1)
-		var/site_type = get_random_digsite_type()
-		for (var/turf/simulated/mineral/T as anything in queue)
-			if (!T.finds)
-				var/list/finds = list()
-				if (prob(50))
-					finds += new /datum/find (site_type, rand(10, 190))
-				else if (prob(75))
-					finds += new /datum/find (site_type, rand(10, 90))
-					finds += new /datum/find (site_type, rand(110, 190))
-				else
-					finds += new /datum/find (site_type, rand(10, 50))
-					finds += new /datum/find (site_type, rand(60, 140))
-					finds += new /datum/find (site_type, rand(150, 190))
-				var/datum/find/F = finds[1]
-				if (F.excavation_required <= F.view_range)
-					T.archaeo_overlay = "overlay_archaeo[rand(1, 3)]"
-					T.update_icon()
-				T.finds = finds
-			if (site_type == DIGSITE_GARDEN)
-				continue
-			if (site_type == DIGSITE_ANIMAL)
-				continue
-			artifact_turfs += T
-		CHECK_TICK
-	GLOB.xeno_digsite_turfs = site_turfs
-	GLOB.xeno_artifact_turfs = list()
-	for (var/i = rand(6, 12) to 1 step -1)
-		var/len = length(artifact_turfs)
-		if (len < 1)
-			break
-		var/selected = rand(1, len)
-		var/turf/simulated/mineral/T = artifact_turfs[selected]
-		artifact_turfs.Cut(selected, selected + 1)
-		// Failsafe for invalid turf types
-		if (!istype(T))
-			continue
-		GLOB.xeno_artifact_turfs += T
-		T.artifact_find = new

--- a/code/controllers/subsystems/initialization/xenoarch.dm
+++ b/code/controllers/subsystems/initialization/xenoarch.dm
@@ -12,7 +12,6 @@ SUBSYSTEM_DEF(xenoarch)
 
 	var/list/artifact_turfs = list()
 	var/static/excavation_turf_chance = 0.5
-	var/static/minimal_distance_between_turfs = 3
 	var/list/banned_levels = map.admin_levels + map.escape_levels
 	for(var/z_level_index in mining_walls)
 		if(text2num(z_level_index) in banned_levels)
@@ -22,7 +21,6 @@ SUBSYSTEM_DEF(xenoarch)
 		if(!length(mining_turfs))
 			continue
 
-		var/list/site_turfs = list()
 		for(var/turf/simulated/mineral/mineral_turf as anything in mining_turfs)
 			if (!mineral_turf.density)
 				continue
@@ -30,20 +28,10 @@ SUBSYSTEM_DEF(xenoarch)
 			if (!mineral_turf.geologic_data)
 				mineral_turf.geologic_data = new(mineral_turf)
 
-			var/has_space = TRUE
-			for(var/turf/site_turf as anything in site_turfs)
-				var/distance_between_turfs = get_dist_euclidian(site_turf, mineral_turf)
-				if(distance_between_turfs > 3)
-					continue
-
-				has_space = FALSE
-				break
-
-			if(!has_space)
+			if(!prob(excavation_turf_chance))
 				continue
 
-			site_turfs += mineral_turf
-
+			xeno_digsite_turfs += mineral_turf
 			var/list/possible_site_turfs = list()
 			for(var/turf/simulated/mineral/T in RANGE_TURFS(mineral_turf, 2))
 				if(!T.density)
@@ -85,8 +73,6 @@ SUBSYSTEM_DEF(xenoarch)
 				artifact_turfs += T
 
 			CHECK_TICK
-
-		xeno_digsite_turfs += site_turfs
 
 	var/xeno_artifact_turfs_amount = min(rand(6, 12), length(artifact_turfs))
 	for (var/i = 1 to xeno_artifact_turfs_amount)

--- a/code/controllers/subsystems/initialization/xenoarch.dm
+++ b/code/controllers/subsystems/initialization/xenoarch.dm
@@ -10,9 +10,7 @@ SUBSYSTEM_DEF(xenoarch)
 	if (!map)
 		return
 
-	var/list/site_turfs = list()
 	var/list/artifact_turfs = list()
-
 	var/static/excavation_turf_chance = 0.5
 	var/static/minimal_distance_between_turfs = 3
 	var/list/banned_levels = map.admin_levels + map.escape_levels
@@ -24,6 +22,7 @@ SUBSYSTEM_DEF(xenoarch)
 		if(!length(mining_turfs))
 			continue
 
+		var/list/site_turfs = list()
 		for(var/turf/simulated/mineral/mineral_turf as anything in mining_turfs)
 			if (!mineral_turf.density)
 				continue
@@ -87,7 +86,7 @@ SUBSYSTEM_DEF(xenoarch)
 
 			CHECK_TICK
 
-	xeno_digsite_turfs += site_turfs
+		xeno_digsite_turfs += site_turfs
 
 	var/xeno_artifact_turfs_amount = min(rand(6, 12), length(artifact_turfs))
 	for (var/i = 1 to xeno_artifact_turfs_amount)

--- a/code/controllers/subsystems/initialization/xenoarch.dm
+++ b/code/controllers/subsystems/initialization/xenoarch.dm
@@ -1,0 +1,100 @@
+SUBSYSTEM_DEF(xenoarch)
+	name = "Xenoarcheology"
+	flags = SS_NO_FIRE
+	init_order = SS_INIT_XENOARCH
+	var/static/list/xeno_artifact_turfs = list()
+	var/static/list/xeno_digsite_turfs = list()
+
+/datum/controller/subsystem/xenoarch/Initialize(start_uptime)
+	var/datum/map/map = GLOB.using_map
+	if (!map)
+		return
+
+	var/list/site_turfs = list()
+	var/list/artifact_turfs = list()
+
+	var/static/excavation_turf_chance = 0.5
+	var/static/minimal_distance_between_turfs = 3
+	var/list/banned_levels = map.admin_levels + map.escape_levels
+	for(var/z_level_index in mining_walls)
+		if(text2num(z_level_index) in banned_levels)
+			continue
+
+		var/list/mining_turfs = mining_walls[z_level_index]
+		if(!length(mining_turfs))
+			continue
+
+		for(var/turf/simulated/mineral/mineral_turf as anything in mining_turfs)
+			if (!mineral_turf.density)
+				continue
+
+			if (!mineral_turf.geologic_data)
+				mineral_turf.geologic_data = new(mineral_turf)
+
+			var/has_space = TRUE
+			for(var/turf/site_turf as anything in site_turfs)
+				var/distance_between_turfs = get_dist_euclidian(site_turf, mineral_turf)
+				if(distance_between_turfs > 3)
+					continue
+
+				has_space = FALSE
+				break
+
+			if(!has_space)
+				continue
+
+			site_turfs += mineral_turf
+
+			var/list/possible_site_turfs = list()
+			for(var/turf/simulated/mineral/T in RANGE_TURFS(mineral_turf, 2))
+				if(!T.density)
+					continue
+
+				if(T.finds)
+					continue
+
+				possible_site_turfs += T
+
+			possible_site_turfs = shuffle(possible_site_turfs)
+			LIST_RESIZE(possible_site_turfs, min(rand(4, 12), length(possible_site_turfs)))
+
+			var/site_type = get_random_digsite_type()
+			for(var/turf/simulated/mineral/T as anything in possible_site_turfs)
+				if(!T.finds)
+					var/list/finds = list()
+					if (prob(50))
+						finds += new /datum/find (site_type, rand(10, 190))
+					else if (prob(75))
+						finds += new /datum/find (site_type, rand(10, 90))
+						finds += new /datum/find (site_type, rand(110, 190))
+					else
+						finds += new /datum/find (site_type, rand(10, 50))
+						finds += new /datum/find (site_type, rand(60, 140))
+						finds += new /datum/find (site_type, rand(150, 190))
+					var/datum/find/F = finds[1]
+					if (F.excavation_required <= F.view_range)
+						T.archaeo_overlay = "overlay_archaeo[rand(1, 3)]"
+						T.update_icon()
+					T.finds = finds
+
+				if(site_type == DIGSITE_GARDEN)
+					continue
+
+				if(site_type == DIGSITE_ANIMAL)
+					continue
+
+				artifact_turfs += T
+
+			CHECK_TICK
+
+	xeno_digsite_turfs += site_turfs
+
+	var/xeno_artifact_turfs_amount = min(rand(6, 12), length(artifact_turfs))
+	for (var/i = 1 to xeno_artifact_turfs_amount)
+		var/turf/simulated/mineral/selected_mineral = pick_n_take(artifact_turfs)
+		// Failsafe for invalid turf types
+		if (!istype(selected_mineral))
+			continue
+
+		xeno_artifact_turfs += selected_mineral
+		selected_mineral.artifact_find = new

--- a/code/controllers/subsystems/machines.dm
+++ b/code/controllers/subsystems/machines.dm
@@ -45,18 +45,16 @@ SUBSYSTEM_DEF(machines)
 	var/static/cost_powernets = 0
 	var/static/cost_power_objects = 0
 	var/static/list/pipenets = list()
-	var/static/list/machinery = list()
-	var/static/list/machinery_by_type = list()
 	var/static/list/powernets = list()
 	var/static/list/power_objects = list()
 	var/static/list/processing = list()
 	var/static/list/queue = list()
-
+	var/static/list/machinery = list()
+	var/static/list/machinery_by_type = list()
 
 /datum/controller/subsystem/machines/Recover()
 	current_step = SSMACHINES_PIPENETS
 	queue.Cut()
-
 
 /datum/controller/subsystem/machines/Initialize(start_uptime)
 	makepowernets()

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -21,13 +21,14 @@ SUBSYSTEM_DEF(mapping)
 	for(var/atype in subtypesof(/singleton/submap_archetype))
 		submap_archetypes[atype] = new atype
 
-
 /datum/controller/subsystem/mapping/Recover()
 	flags |= SS_NO_INIT
 	map_templates = SSmapping.map_templates
 	space_ruins_templates = SSmapping.space_ruins_templates
 	exoplanet_ruins_templates = SSmapping.exoplanet_ruins_templates
 	away_sites_templates = SSmapping.away_sites_templates
+	submaps = SSmapping.submaps
+	submap_archetypes = SSmapping.submap_archetypes
 
 /datum/controller/subsystem/mapping/proc/preloadTemplates(path = "maps/templates/") //see master controller setup
 	var/list/filelist = flist(path)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -41,16 +41,13 @@ var/global/list/mining_floors = list()
 
 /turf/simulated/mineral/Initialize()
 	. = ..()
-	if (!mining_walls["[src.z]"])
-		mining_walls["[src.z]"] = list()
-	mining_walls["[src.z]"] += src
+	LAZYADDASSOCLIST(mining_walls, "[z]", src)
 	MineralSpread()
 	update_icon(1)
 
 /turf/simulated/mineral/Destroy()
-	if (mining_walls["[src.z]"])
-		mining_walls["[src.z]"] -= src
-	GLOB.xeno_artifact_turfs -= src
+	LAZYREMOVEASSOC(mining_walls, "[z]", src)
+	SSxenoarch.xeno_artifact_turfs -= src
 	return ..()
 
 /turf/simulated/mineral/can_build_cable()
@@ -423,15 +420,12 @@ var/global/list/mining_floors = list()
 
 /turf/simulated/floor/asteroid/Initialize()
 	. = ..()
-	if (!mining_floors["[src.z]"])
-		mining_floors["[src.z]"] = list()
-	mining_floors["[src.z]"] += src
+	LAZYADDASSOCLIST(mining_floors, "[z]", src)
 	if(prob(20))
 		overlay_detail = "asteroid[rand(0,9)]"
 
 /turf/simulated/floor/asteroid/Destroy()
-	if (mining_floors["[src.z]"])
-		mining_floors["[src.z]"] -= src
+	LAZYREMOVEASSOC(mining_floors, "[z]", src)
 	return ..()
 
 /turf/simulated/floor/asteroid/ex_act(severity)

--- a/code/modules/xenoarcheaology/sampling.dm
+++ b/code/modules/xenoarcheaology/sampling.dm
@@ -70,14 +70,14 @@
 		artifact_distance = rand()
 		artifact_id = container.artifact_find.artifact_id
 	else
-		for (var/turf/simulated/mineral/T as anything in GLOB.xeno_artifact_turfs)
+		for (var/turf/simulated/mineral/T as anything in SSxenoarch.xeno_artifact_turfs)
 			if(T.artifact_find)
 				var/cur_dist = get_dist(container, T) * 2
 				if( (artifact_distance < 0 || cur_dist < artifact_distance))
 					artifact_distance = cur_dist + rand() * 2 - 1
 					artifact_id = T.artifact_find.artifact_id
 			else
-				GLOB.xeno_artifact_turfs -= T
+				SSxenoarch.xeno_artifact_turfs -= T
 
 /obj/item/device/core_sampler
 	name = "core sampler"

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -57,7 +57,7 @@
 		var/nearestSimpleTargetDist = -1
 		var/turf/cur_turf = get_turf(src)
 
-		for (var/turf/simulated/mineral/T as anything in GLOB.xeno_artifact_turfs)
+		for (var/turf/simulated/mineral/T as anything in SSxenoarch.xeno_artifact_turfs)
 			if(T.density && T.artifact_find)
 				if(T.z == cur_turf.z)
 					var/cur_dist = get_dist(cur_turf, T) * 2
@@ -65,16 +65,16 @@
 						nearestTargetDist = cur_dist + rand() * 2 - 1
 						nearestTargetId = T.artifact_find.artifact_id
 			else
-				GLOB.xeno_artifact_turfs -= T
+				SSxenoarch.xeno_artifact_turfs -= T
 
-		for(var/turf/simulated/mineral/T as anything in GLOB.xeno_digsite_turfs)
+		for(var/turf/simulated/mineral/T as anything in SSxenoarch.xeno_artifact_turfs)
 			if(T.density && T.finds && length(T.finds))
 				if(T.z == cur_turf.z)
 					var/cur_dist = get_dist(cur_turf, T) * 2
 					if(nearestSimpleTargetDist < 0 || cur_dist < nearestSimpleTargetDist)
 						nearestSimpleTargetDist = cur_dist + rand() * 2 - 1
 			else
-				GLOB.xeno_digsite_turfs -= T
+				SSxenoarch.xeno_digsite_turfs -= T
 
 		if(nearestTargetDist >= 0)
 			to_chat(user, SPAN_NOTICE("Exotic energy detected on wavelength '[nearestTargetId]' in a radius of [nearestTargetDist]m[nearestSimpleTargetDist > 0 ? "; small anomaly detected in a radius of [nearestSimpleTargetDist]m" : ""]"))

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -462,8 +462,9 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	if(!use_overmap)
 		return
 
+	var/static/list/exoplanet_types = subtypesof(/obj/overmap/visitable/sector/exoplanet)
 	for(var/i = 0, i < num_exoplanets, i++)
-		var/exoplanet_type = pick(subtypesof(/obj/overmap/visitable/sector/exoplanet))
+		var/exoplanet_type = pick(exoplanet_types)
 		var/obj/overmap/visitable/sector/exoplanet/new_planet = new exoplanet_type(null, planet_size[1], planet_size[2])
 		new_planet.build_level()
 


### PR DESCRIPTION
## Что этот PR делает

Ксеноархеология теперь инициализируется за 0 секунд.
Не проходим по всему миру, чтобы отыскать турфы с рудой, а по кешу

## Почему это хорошо для игры

Быстрее инициализация

## Тестирование

Без рантаймов, турфы для артефактов выбирает корректно

## Changelog

:cl:
fix: Скорость инициализации археологии снижена до почти минимума
/:cl:
