### PR TITLE
fix: don't qdel primitive types

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -206,6 +206,7 @@ SUBSYSTEM_DEF(garbage)
 
 	if(!istype(datum))
 		crash_with("qdel() can only handle /datum (sub)types, was passed: [log_info_line(datum)]")
+		return
 
 	var/static/list/details_by_path = SSgarbage.details_by_path
 	var/static/list/collection_queue = SSgarbage.collection_queue

--- a/code/modules/tgui/tgui_input/list_input.dm
+++ b/code/modules/tgui/tgui_input/list_input.dm
@@ -103,7 +103,7 @@
 /datum/tgui_list_input/Destroy(force)
 	SStgui.close_uis(src)
 	state = null
-	QDEL_NULL(items)
+	items = null
 	return ..()
 
 /**


### PR DESCRIPTION
## Что этот PR делает

Не вызывает qdel на списке примитивов. 

## Тестирование

Компилится, рантаймов нет в тех местах где были. 

