### PR TITLE
MAPFIX: Farfleet papers and Sierra issue fixes

### DIFF
--- a/code/modules/mining/machinery/mineral_console.dm
+++ b/code/modules/mining/machinery/mineral_console.dm
@@ -4,6 +4,9 @@
 	icon_state = "console"
 	machine_name = "mineral processing console"
 	machine_desc = "Used to configure and operate a linked ore processor, and capable of processing minerals in a variety of fashions."
+	// [SS220 EDIT]
+	density = 0
+	// [/SS220 EDIT]
 	var/obj/machinery/mineral/connected
 
 /obj/machinery/computer/mining/interface_interact(mob/user)

--- a/code/modules/mining/machinery/mineral_console.dm
+++ b/code/modules/mining/machinery/mineral_console.dm
@@ -4,9 +4,6 @@
 	icon_state = "console"
 	machine_name = "mineral processing console"
 	machine_desc = "Used to configure and operate a linked ore processor, and capable of processing minerals in a variety of fashions."
-	// [SS220 EDIT]
-	density = 0
-	// [/SS220 EDIT]
 	var/obj/machinery/mineral/connected
 
 /obj/machinery/computer/mining/interface_interact(mob/user)

--- a/maps/sierra/job/jobs_cargo.dm
+++ b/maps/sierra/job/jobs_cargo.dm
@@ -74,8 +74,8 @@
 	title = "Prospector"
 	department = "Снабжения"
 	department_flag = SUP
-	total_positions = 4
-	spawn_positions = 4
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = "Квартирмейстеру и Главе Персонала"
 	selection_color = "#515151"
 	economic_power = 7

--- a/mods/_maps/farfleet/maps/farfleet-1.dmm
+++ b/mods/_maps/farfleet/maps/farfleet-1.dmm
@@ -3556,6 +3556,14 @@
 /obj/floor_decal/corner/darkblue/border{
 	dir = 9
 	},
+/obj/item/paper_bin,
+/obj/item/pen/blue,
+/obj/item/pen/red{
+	pixel_y = 3
+	},
+/obj/item/pen{
+	pixel_y = 6
+	},
 /turf/simulated/floor/tiled/dark,
 /area/ship/farfleet/command/bridge)
 "oz" = (

--- a/mods/_maps/farfleet/maps/farfleet-2.dmm
+++ b/mods/_maps/farfleet/maps/farfleet-2.dmm
@@ -109,6 +109,11 @@
 /obj/item/stack/package_wrap/cargo_wrap,
 /turf/simulated/floor/tiled/white,
 /area/ship/farfleet/crew/kitchen)
+"ba" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/slide_projector,
+/turf/simulated/floor/tiled/dark,
+/area/ship/farfleet/barracks)
 "bg" = (
 /obj/machinery/radio_beacon,
 /turf/simulated/floor/tiled/steel_grid,
@@ -1181,6 +1186,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/snz)
 "lT" = (
@@ -1346,6 +1352,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/floor_decal/industrial/outline/red,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "nL" = (
@@ -2265,6 +2272,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/snz)
 "wi" = (
@@ -2282,6 +2290,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "wr" = (
@@ -2646,6 +2655,7 @@
 /area/ship/farfleet/barracks)
 "zk" = (
 /obj/machinery/recharge_station,
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "zp" = (
@@ -3056,6 +3066,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/snz)
 "Dj" = (
@@ -3075,6 +3086,7 @@
 "Dk" = (
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/portables_connector,
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "Dl" = (
@@ -3409,6 +3421,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/storage/box/canned_tomato,
+/obj/item/storage/box/canned_beef,
+/obj/item/storage/box/canned_beans,
+/obj/item/reagent_containers/food/snacks/canned/caviar/true,
+/obj/item/reagent_containers/food/snacks/canned/caviar/true,
+/obj/item/reagent_containers/food/snacks/canned/caviar/true,
 /turf/simulated/floor/tiled/freezer,
 /area/ship/farfleet/crew/freezer)
 "Gg" = (
@@ -3746,6 +3764,7 @@
 	start_pressure = 8000;
 	dir = 4
 	},
+/obj/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "KE" = (
@@ -3877,6 +3896,7 @@
 	icon_state = "map_connector"
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "LS" = (
@@ -3984,6 +4004,12 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/ship/farfleet/maintenance/storage)
+"Ne" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen/multi,
+/turf/simulated/floor/tiled/dark,
+/area/ship/farfleet/barracks)
 "Nl" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/door/firedoor,
@@ -4111,6 +4137,14 @@
 /obj/floor_decal/corner_steel_grid/diagonal,
 /turf/simulated/floor/tiled,
 /area/ship/farfleet/crew/hydroponics)
+"Oj" = (
+/obj/floor_decal/corner/b_green/diagonal{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/board,
+/turf/simulated/floor/tiled/white,
+/area/ship/farfleet/crew/canteen)
 "Ol" = (
 /obj/machinery/computer/ship/sensors,
 /obj/machinery/light{
@@ -4312,6 +4346,7 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
+/obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/dark,
 /area/ship/farfleet/barracks)
 "QZ" = (
@@ -4412,6 +4447,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/floor_decal/industrial/outline,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "RU" = (
@@ -4592,6 +4628,14 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/ship/farfleet/crew/canteen)
+"Tk" = (
+/obj/floor_decal/corner/b_green/diagonal{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/storage/box/checkers,
+/turf/simulated/floor/tiled/white,
+/area/ship/farfleet/crew/canteen)
 "Tm" = (
 /obj/paint/dark_gunmetal,
 /obj/structure/cable{
@@ -4681,6 +4725,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/ship/snz)
 "TX" = (
@@ -4739,10 +4784,10 @@
 /area/ship/farfleet/barracks)
 "Ux" = (
 /obj/machinery/bodyscanner{
-	dir = 4;
-	icon_state = "body_scanner_0"
+	dir = 4
 	},
 /obj/machinery/light,
+/obj/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/tiled/white,
 /area/ship/snz)
 "UF" = (
@@ -11566,8 +11611,8 @@ vt
 Je
 MT
 VA
-Ac
-Ac
+Oj
+Tk
 Wd
 Ye
 cO
@@ -14115,7 +14160,7 @@ Ab
 Ll
 Ll
 Uu
-uA
+Ne
 wi
 Db
 Ll
@@ -14237,7 +14282,7 @@ Ab
 Ll
 Ll
 Fr
-uA
+ba
 mQ
 mQ
 Ll

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -50,7 +50,7 @@ exactly 1 "NOOP match" 'NOOP'
 exactly 335 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
-exactly 2 "density = 0/1" 'density\s*=\s*\d' -P
+exactly 3 "density = 0/1" 'density\s*=\s*\d' -P
 exactly 0 "emagged = 0/1" 'emagged\s*=\s*\d' -P
 exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -50,7 +50,7 @@ exactly 1 "NOOP match" 'NOOP'
 exactly 335 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
-exactly 3 "density = 0/1" 'density\s*=\s*\d' -P
+exactly 2 "density = 0/1" 'density\s*=\s*\d' -P
 exactly 0 "emagged = 0/1" 'emagged\s*=\s*\d' -P
 exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P


### PR DESCRIPTION
## Что этот PR делает

Работа с отзывами пользователей о недочётах карты Пионерского Корпуса. Добавлен ряд вещей
* Бумага на мостик и в брифинг + проектор в брифинг
* Банки с икрой и консервы в холодильник
* Шашки в столовую

## Почему это хорошо для игры

Исправление проблем с отсутствием QoL вещей для ГКК

## Тестирование

Локально запускал карту. Уверяю, мне можно доверить мапфиксы
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog
:cl: LordNest
add: Различные QoL вещи для ГКК.
fix: Теперь холодильники и шахтёрские консоли не скрываются под стенками, потому что стенок нет. 
fix: Количество шахтёров уменьшено до 3, как и планировалось (откуда притащили четвертого - загадка)
/:cl: