### PR TITLE
Removes remnants of my enthusiasm

### DIFF
--- a/code/__defines/dcs/signals/signals_atom.dm
+++ b/code/__defines/dcs/signals/signals_atom.dm
@@ -8,3 +8,8 @@
 #define COMSIG_ATOM_ENTERED "atom_entered"
 /// Sent from the atom that just Entered src. From base of atom/Entered(): (/atom/destination, atom/old_loc, list/atom/old_locs)
 #define COMSIG_ATOM_ENTERING "atom_entering"
+
+
+//machinery
+#define COMSIG_AREA_APC_DELETED "area_apc_gone"
+#define COMSIG_AREA_APC_POWER_CHANGE "area_apc_power_change"

--- a/code/game/area/area_power.dm
+++ b/code/game/area/area_power.dm
@@ -28,6 +28,7 @@
 /area/proc/power_change()
 	for(var/obj/machinery/M as anything in machinery_list)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_APC_POWER_CHANGE)
 	if (fire || eject || party)
 		update_icon()
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1072,15 +1072,16 @@ FIRE ALARM
 	if(inoperable())
 		return
 
-	if(src.timing)
-		if(src.time > 0)
-			src.time = src.time - ((world.timeofday - last_process)/10)
+	if(timing)
+		if(time > 0)
+			time -= (world.timeofday - last_process)/10
+
 		else
-			src.alarm()
-			src.time = 0
-			src.timing = 0
+			alarm()
+			time = 0
+			timing = 0
 			STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
-		src.updateDialog()
+		updateDialog()
 	last_process = world.timeofday
 
 	if(locate(/obj/hotspot) in loc)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -195,6 +195,7 @@
 /obj/machinery/power/apc/Destroy()
 	src.update()
 	area.apc = null
+	SEND_SIGNAL(area, COMSIG_AREA_APC_DELETED)
 	area.power_light = 0
 	area.power_equip = 0
 	area.power_environ = 0


### PR DESCRIPTION
Удаляет process() из интеркомов, теперь они работают на основе сигналов, добавляет сигнал при удалении APC зоны и при смене питания в зоне. Влез в фаералярму, чтобы в ней при компиляции src.time не превращалось в src.src.time. 

Нужно процессить на 490 объектов меньше (охуеть на кой ляд сыру столько интеркомов) 