### PR TITLE
Fix: looc cant be viewed by blind mobs

### DIFF
--- a/code/datums/communication/looc.dm
+++ b/code/datums/communication/looc.dm
@@ -18,7 +18,7 @@
 
 /singleton/communication_channel/ooc/looc/do_communicate(client/C, message)
 	var/mob/M = C.mob ? C.mob.get_looc_mob() : null
-	var/list/listening_hosts = hosts_in_view_range(M)
+	var/list/listening_hosts = hearers_in_range(M)
 	var/list/listening_clients = list()
 
 	var/key = C.key


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Дает видеть лоок всем мобам в рендже world.view
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

## Изображения изменений
<details>
<summary>Скриншоты</summary>

</details>

<details>
<summary>Видео</summary>

</details>

<!-- Если вы не меняли карту или спрайты, можете опустить эту секцию. Если хотите, можете вставить видео. -->

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
fix: Теперь лоок видно в отключке
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
