### PR TITLE
Refactor: Status display logic

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -61,11 +61,12 @@
 	playsound(src, "shatter", 70, 1)
 	visible_message(SPAN_DANGER("\The [src] is smashed into many pieces!"))
 	remove_display()
-	STOP_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	on_machine_broken()
+
 
 /obj/machinery/status_display/on_revive()
 	..()
-	START_PROCESSING_MACHINE(src, MACHINERY_PROCESS_SELF)
+	on_machine_fixed()
 
 /obj/machinery/status_display/on_update_icon()
 	if (MACHINE_IS_BROKEN(src))
@@ -92,16 +93,9 @@
 	. = ..()
 	if(radio_controller)
 		radio_controller.add_object(src, frequency)
-
-// timed process
-/obj/machinery/status_display/Process()
-	if (MACHINE_IS_BROKEN(src))
-		return PROCESS_KILL
-	if(!is_powered())
-		remove_display()
-		return
 	update()
 
+// EMP
 /obj/machinery/status_display/emp_act(severity)
 	if(inoperable())
 		..(severity)
@@ -109,10 +103,20 @@
 	set_picture("ai_bsod")
 	..(severity)
 
+// how we operate
+
+/obj/machinery/status_display/proc/on_machine_broken()
+	return
+
+/obj/machinery/status_display/proc/on_machine_fixed()
+	update()
+
 // set what is displayed
 /obj/machinery/status_display/proc/update()
 	remove_display()
 	if (MACHINE_IS_BROKEN(src))
+		return
+	if (stat & MACHINE_STAT_NOPOWER)
 		return
 	if(friendc && !ignore_friendc)
 		set_picture("ai_friend")

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -61,12 +61,10 @@
 	playsound(src, "shatter", 70, 1)
 	visible_message(SPAN_DANGER("\The [src] is smashed into many pieces!"))
 	remove_display()
-	on_machine_broken()
-
 
 /obj/machinery/status_display/on_revive()
 	..()
-	on_machine_fixed()
+	update()
 
 /obj/machinery/status_display/on_update_icon()
 	if (MACHINE_IS_BROKEN(src))
@@ -95,7 +93,6 @@
 		radio_controller.add_object(src, frequency)
 	update()
 
-// EMP
 /obj/machinery/status_display/emp_act(severity)
 	if(inoperable())
 		..(severity)
@@ -103,20 +100,10 @@
 	set_picture("ai_bsod")
 	..(severity)
 
-// how we operate
-
-/obj/machinery/status_display/proc/on_machine_broken()
-	return
-
-/obj/machinery/status_display/proc/on_machine_fixed()
-	update()
-
 // set what is displayed
 /obj/machinery/status_display/proc/update()
 	remove_display()
-	if (MACHINE_IS_BROKEN(src))
-		return
-	if (stat & MACHINE_STAT_NOPOWER)
+	if (!operable())
 		return
 	if(friendc && !ignore_friendc)
 		set_picture("ai_friend")

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -91,7 +91,7 @@
 	. = ..()
 	if(radio_controller)
 		radio_controller.add_object(src, frequency)
-	update()
+
 
 /obj/machinery/status_display/emp_act(severity)
 	if(inoperable())

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -134,6 +134,7 @@
 /obj/machinery/status_display/proc/change_status()
 	SIGNAL_HANDLER
 
+	power_channel = linked_area.powered(EQUIP)
 	update()
 
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

No user facing changes
Depends on #156 
<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

## Почему это хорошо для игры

Оптимизирует работу статус дисплеев, делая её гораздо менее ресурозатратной
<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->


## Тестирование

Тестировалось локально
<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl: LordNest
tweak: Изменена логика работы статус дисплеев
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
