### PR TITLE
welder_act feedback standartization

### DIFF
--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -17,3 +17,6 @@
 #define USE_FEEDBACK_GRAB_FAILURE(MSG) FEEDBACK_FAILURE(grab.assailant, MSG)
 /// Assailant must upgrade their grab to perform action.
 #define USE_FEEDBACK_GRAB_MUST_UPGRADE(ACTION) USE_FEEDBACK_GRAB_FAILURE("You need a better grip on \the [grab.affecting][ACTION].")
+
+/// Feedback messages for repairs done by welder_act()
+#define USE_FEEDBACK_REPAIR_GENERAL user.visible_message(SPAN_NOTICE("[user] finishes repairing the damage to [src]"), SPAN_NOTICE("You finish repairing the damage to [src]."))

--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -20,21 +20,21 @@
 
 
 /// Feedback message when user needs to unanchor the target
-#define USE_FEEDBACK_NEED_UNANCHOR balloon_alert(user, "нужно открутить от пола!")
+#define USE_FEEDBACK_NEED_UNANCHOR(user) balloon_alert(user, "нужно открутить от пола!")
 /// Feedback message when user needs to unanchor the target
-#define USE_FEEDBACK_NEED_ANCHOR balloon_alert(user, "нужно прикрутить к полу!")
+#define USE_FEEDBACK_NEED_ANCHOR(user) balloon_alert(user, "нужно прикрутить к полу!")
 /// Feedback message when user starts deconstructing the target
-#define USE_FEEDBACK_DECONSTRUCT_START balloon_alert(user, "разбор")
+#define USE_FEEDBACK_DECONSTRUCT_START(user) balloon_alert(user, "разбор")
 /// Feedback message when user starts welding/unwelding the target
-#define USE_FEEDBACK_WELD_UNWELD(welded) balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
+#define USE_FEEDBACK_WELD_UNWELD(user, welded) balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
 /// Feedback message when user finishes welding/unwelding the target
-#define USE_FEEDBACK_WELD_UNWELD_FINISH(welded) balloon_alert_to_viewers("[welded ? "заварено!" : "отварено!"]")
+#define USE_FEEDBACK_WELD_UNWELD_FINISH(user, welded) balloon_alert_to_viewers("[welded ? "заварено!" : "отварено!"]")
 /// Feedback message when user starts unwelding target from the floor
-#define USE_FEEDBACK_UNWELD_FROM_FLOOR balloon_alert(user, "отваривание от пола")
+#define USE_FEEDBACK_UNWELD_FROM_FLOOR(user) balloon_alert(user, "отваривание от пола")
 
 /// Feedback message when user starts repairing the target
-#define USE_FEEDBACK_REPAIR_START balloon_alert(user, "ремонт")
+#define USE_FEEDBACK_REPAIR_START(user) balloon_alert(user, "ремонт")
 /// Feedback message when user finishes the repairs
-#define USE_FEEDBACK_REPAIR_FINISH balloon_alert_to_viewers("ремонт завершен!")
+#define USE_FEEDBACK_REPAIR_FINISH(user) balloon_alert_to_viewers("ремонт завершен!")
 /// Feedback message when the target doesn't need repairs
-#define USE_FEEDBACK_NOTHING_TO_REPAIR balloon_alert(user, "нет повреждений!")
+#define USE_FEEDBACK_NOTHING_TO_REPAIR(user) balloon_alert(user, "нет повреждений!")

--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -27,12 +27,14 @@
 #define USE_FEEDBACK_DECONSTRUCT_START balloon_alert(user, "разбор")
 /// Feedback message when user starts welding/unwelding the target
 #define USE_FEEDBACK_WELD_UNWELD(welded) balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
+/// Feedback message when user finishes welding/unwelding the target
+#define USE_FEEDBACK_WELD_UNWELD_FINISH(welded) balloon_alert_to_viewers("[welded ? "заварено!" : "отварено!"]")
 /// Feedback message when user starts unwelding target from the floor
 #define USE_FEEDBACK_UNWELD_FROM_FLOOR balloon_alert(user, "отваривание от пола")
 
 /// Feedback message when user starts repairing the target
 #define USE_FEEDBACK_REPAIR_START balloon_alert(user, "ремонт")
 /// Feedback message when user finishes the repairs
-#define USE_FEEDBACK_REPAIR_FINISH user.visible_message(SPAN_NOTICE("[user] finishes repairing the damage to [src]"), SPAN_NOTICE("You finish repairing the damage to [src]."))
+#define USE_FEEDBACK_REPAIR_FINISH balloon_alert_to_viewers("ремонт завершен!")
 /// Feedback message when the target doesn't need repairs
 #define USE_FEEDBACK_NOTHING_TO_REPAIR balloon_alert(user, "нет повреждений!")

--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -18,5 +18,21 @@
 /// Assailant must upgrade their grab to perform action.
 #define USE_FEEDBACK_GRAB_MUST_UPGRADE(ACTION) USE_FEEDBACK_GRAB_FAILURE("You need a better grip on \the [grab.affecting][ACTION].")
 
-/// Feedback messages for repairs done by welder_act()
-#define USE_FEEDBACK_REPAIR_GENERAL user.visible_message(SPAN_NOTICE("[user] finishes repairing the damage to [src]"), SPAN_NOTICE("You finish repairing the damage to [src]."))
+
+/// Feedback message when user needs to unanchor the target
+#define USE_FEEDBACK_NEED_UNANCHOR balloon_alert(user, "нужно открутить от пола!")
+/// Feedback message when user needs to unanchor the target
+#define USE_FEEDBACK_NEED_ANCHOR balloon_alert(user, "нужно прикрутить к полу!")
+/// Feedback message when user starts deconstructing the target
+#define USE_FEEDBACK_DECONSTRUCT_START balloon_alert(user, "разбор")
+/// Feedback message when user starts welding/unwelding the target
+#define USE_FEEDBACK_WELD_UNWELD(welded) balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
+/// Feedback message when user starts unwelding target from the floor
+#define USE_FEEDBACK_UNWELD_FROM_FLOOR balloon_alert(user, "отваривание от пола")
+
+/// Feedback message when user starts repairing the target
+#define USE_FEEDBACK_REPAIR_START balloon_alert(user, "ремонт")
+/// Feedback message when user finishes the repairs
+#define USE_FEEDBACK_REPAIR_FINISH user.visible_message(SPAN_NOTICE("[user] finishes repairing the damage to [src]"), SPAN_NOTICE("You finish repairing the damage to [src]."))
+/// Feedback message when the target doesn't need repairs
+#define USE_FEEDBACK_NOTHING_TO_REPAIR balloon_alert(user, "нет повреждений!")

--- a/code/game/machinery/_machines_base/machine_construction/frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/frame.dm
@@ -21,7 +21,7 @@
 	if(I.tool_behaviour == TOOL_WELDER)
 		if(!I.tool_start_check(user, 3))
 			return TRUE
-		machine.balloon_alert(user, "начало разбора")
+		machine.balloon_alert(user, "разбор")
 		if(!I.use_as_tool(machine, user, 2 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return TRUE
 		TRANSFER_STATE(/singleton/machine_construction/default/deconstructed)

--- a/code/game/machinery/_machines_base/machine_construction/frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/frame.dm
@@ -21,10 +21,10 @@
 	if(I.tool_behaviour == TOOL_WELDER)
 		if(!I.tool_start_check(user, 3))
 			return TRUE
+		machine.balloon_alert(user, "начало разбора")
 		if(!I.use_as_tool(machine, user, 2 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return TRUE
 		TRANSFER_STATE(/singleton/machine_construction/default/deconstructed)
-		to_chat(user, SPAN_NOTICE("You deconstruct [machine]."))
 		machine.dismantle()
 
 

--- a/code/game/machinery/_machines_base/machine_construction/frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/frame.dm
@@ -21,7 +21,7 @@
 	if(I.tool_behaviour == TOOL_WELDER)
 		if(!I.tool_start_check(user, 3))
 			return TRUE
-		machine.USE_FEEDBACK_DECONSTRUCT_START
+		machine.USE_FEEDBACK_DECONSTRUCT_START(user)
 		if(!I.use_as_tool(machine, user, 2 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return TRUE
 		TRANSFER_STATE(/singleton/machine_construction/default/deconstructed)

--- a/code/game/machinery/_machines_base/machine_construction/frame.dm
+++ b/code/game/machinery/_machines_base/machine_construction/frame.dm
@@ -21,7 +21,7 @@
 	if(I.tool_behaviour == TOOL_WELDER)
 		if(!I.tool_start_check(user, 3))
 			return TRUE
-		machine.balloon_alert(user, "разбор")
+		machine.USE_FEEDBACK_DECONSTRUCT_START
 		if(!I.use_as_tool(machine, user, 2 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return TRUE
 		TRANSFER_STATE(/singleton/machine_construction/default/deconstructed)

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -28,7 +28,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	emagged = FALSE

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -28,11 +28,11 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	emagged = FALSE
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	if(locked)
 		visible_message(
 			"[src]'s clamps engage, locking onto [get_turf(src)].",

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -28,11 +28,11 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	emagged = FALSE
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	if(locked)
 		playsound(src, 'sound/machines/bolts_down.ogg', 50, TRUE)
 		anchored = TRUE

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -24,19 +24,15 @@
 /obj/machinery/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!emagged)
-		to_chat(user, SPAN_WARNING("[src]'s locking clamps are not damaged."))
+		balloon_alert(user, "фиксаторы не повреждены")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		"[user] starts to repair [src]'s locking clamps with \an [tool].",
-		"You start to repair [src]'s locking clamps with [tool].",
-		"You hear a hissing flame."
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, SPAN_NOTICE("You finished repairing [src]'s locking clamps."))
 	emagged = FALSE
+	USE_FEEDBACK_REPAIR_GENERAL
 	if(locked)
 		visible_message(
 			"[src]'s clamps engage, locking onto [get_turf(src)].",

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -24,7 +24,7 @@
 /obj/machinery/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!emagged)
-		balloon_alert(user, "фиксаторы не повреждены")
+		balloon_alert(user, "фиксаторы не повреждены!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
@@ -34,11 +34,7 @@
 	emagged = FALSE
 	USE_FEEDBACK_REPAIR_FINISH
 	if(locked)
-		visible_message(
-			"[src]'s clamps engage, locking onto [get_turf(src)].",
-			"You hear metal sliding and creaking.",
-			range = 5
-		)
+		playsound(src, 'sound/machines/bolts_down.ogg', 50, TRUE)
 		anchored = TRUE
 	update_icon()
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -206,11 +206,11 @@
 			assembly.dir = dir
 			if(MACHINE_IS_BROKEN(src))
 				assembly.state = 2
-				balloon_alert(user, "камера отремонтирована")
+				user.balloon_alert_to_viewers("камера отремонтирована")
 				cancelCameraAlarm()
 			else
 				assembly.state = 1
-				balloon_alert(user, "камера отварена от стены")
+				user.balloon_alert_to_viewers("камера отварена от стены")
 				new /obj/item/stack/cable_coil(loc, 2)
 			assembly = null //so qdel doesn't eat it.
 		qdel(src)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,7 +194,7 @@
 	if(camera_wires.CanDeconstruct() || (MACHINE_IS_BROKEN(src)))
 		if(!tool.tool_start_check(user, 1))
 			return
-		balloon_alert(user, "разбор")
+		USE_FEEDBACK_DECONSTRUCT_START
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
 		if(assembly)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,7 +194,7 @@
 	if(camera_wires.CanDeconstruct() || (MACHINE_IS_BROKEN(src)))
 		if(!tool.tool_start_check(user, 1))
 			return
-		USE_FEEDBACK_DECONSTRUCT_START
+		USE_FEEDBACK_DECONSTRUCT_START(user)
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
 		if(assembly)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,7 +194,7 @@
 	if(camera_wires.CanDeconstruct() || (MACHINE_IS_BROKEN(src)))
 		if(!tool.tool_start_check(user, 1))
 			return
-		balloon_alert(user, "начало разбора")
+		balloon_alert(user, "разбор")
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
 		if(assembly)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -192,24 +192,28 @@
 	. = ITEM_INTERACT_SUCCESS
 	var/datum/wires/camera/camera_wires = wires
 	if(camera_wires.CanDeconstruct() || (MACHINE_IS_BROKEN(src)))
-		if(weld(tool, user))
-			if(assembly)
-				assembly.dropInto(loc)
-				assembly.anchored = TRUE
-				assembly.camera_name = c_tag
-				assembly.camera_network = english_list(network, "Exodus", ",", ",")
-				assembly.update_icon()
-				assembly.dir = dir
-				if(MACHINE_IS_BROKEN(src))
-					assembly.state = 2
-					to_chat(user, SPAN_NOTICE("You repaired [src] frame."))
-					cancelCameraAlarm()
-				else
-					assembly.state = 1
-					to_chat(user, SPAN_NOTICE("You cut [src] free from the wall."))
-					new /obj/item/stack/cable_coil(loc, 2)
-				assembly = null //so qdel doesn't eat it.
-			qdel(src)
+		if(!tool.tool_start_check(user, 1))
+			return
+		balloon_alert(user, "начало разбора")
+		if(!tool.use_as_tool(src, user, 10 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
+			return
+		if(assembly)
+			assembly.dropInto(loc)
+			assembly.anchored = TRUE
+			assembly.camera_name = c_tag
+			assembly.camera_network = english_list(network, "Exodus", ",", ",")
+			assembly.update_icon()
+			assembly.dir = dir
+			if(MACHINE_IS_BROKEN(src))
+				assembly.state = 2
+				balloon_alert(user, "камера отремонтирована")
+				cancelCameraAlarm()
+			else
+				assembly.state = 1
+				balloon_alert(user, "камера отварена от стены")
+				new /obj/item/stack/cable_coil(loc, 2)
+			assembly = null //so qdel doesn't eat it.
+		qdel(src)
 
 /obj/machinery/camera/use_tool(obj/item/W, mob/living/user, list/click_params)
 	update_coverage()
@@ -389,14 +393,6 @@
 			return C
 
 	return null
-
-/obj/machinery/camera/proc/weld(obj/item/tool, mob/user)
-	if(!tool.tool_start_check(user, 1))
-		return FALSE
-	to_chat(user, SPAN_NOTICE("You start to weld [src].."))
-	if(!tool.use_as_tool(src, user, 10 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
-		return FALSE
-	return TRUE
 
 /obj/machinery/camera/proc/add_network(network_name)
 	add_networks(list(network_name))

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -106,7 +106,7 @@
 			balloon_alert(user, "приваривание камеры")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
-			balloon_alert(user, "камера приварена")
+			balloon_alert_to_viewers("камера приварена")
 			anchored = TRUE
 			state = ASSEMBLY_WELDED
 		if(ASSEMBLY_WELDED)
@@ -115,7 +115,7 @@
 			balloon_alert(user, "отваривание камеры")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
-			balloon_alert(user, "камера отварена")
+			balloon_alert_to_viewers("камера отварена")
 			state = ASSEMBLY_WRENCHED
 			anchored = TRUE
 

--- a/code/game/machinery/camera/camera_assembly.dm
+++ b/code/game/machinery/camera/camera_assembly.dm
@@ -101,15 +101,23 @@
 	. = ITEM_INTERACT_SUCCESS
 	switch(state)
 		if(ASSEMBLY_WRENCHED)
-			if(weld(tool, user))
-				to_chat(user, "You weld the assembly securely into place.")
-				anchored = TRUE
-				state = ASSEMBLY_WELDED
+			if(!tool.tool_start_check(user, 1))
+				return
+			balloon_alert(user, "приваривание камеры")
+			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
+				return
+			balloon_alert(user, "камера приварена")
+			anchored = TRUE
+			state = ASSEMBLY_WELDED
 		if(ASSEMBLY_WELDED)
-			if(weld(tool, user))
-				to_chat(user, "You unweld the assembly from its place.")
-				state = ASSEMBLY_WRENCHED
-				anchored = TRUE
+			if(!tool.tool_start_check(user, 1))
+				return
+			balloon_alert(user, "отваривание камеры")
+			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
+				return
+			balloon_alert(user, "камера отварена")
+			state = ASSEMBLY_WRENCHED
+			anchored = TRUE
 
 /obj/item/camera_assembly/attackby(obj/item/W as obj, mob/living/user as mob)
 	switch(state)
@@ -140,14 +148,6 @@
 /obj/item/camera_assembly/attack_hand(mob/user as mob)
 	if(!anchored)
 		..()
-
-/obj/item/camera_assembly/proc/weld(obj/item/tool, mob/user)
-	if(!tool.tool_start_check(user, 1))
-		return FALSE
-	to_chat(user, SPAN_NOTICE("You start to weld [src].."))
-	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
-		return FALSE
-	return TRUE
 
 #undef ASSEMBLY_NONE
 #undef ASSEMBLY_WRENCHED

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -353,11 +353,11 @@ var/global/list/empty_playable_ai_cores = list()
 	if (tool.tool_behaviour == TOOL_WELDER)
 		if (state == STATE_FRAME)
 			if(anchored)
-				USE_FEEDBACK_NEED_UNANCHOR
+				USE_FEEDBACK_NEED_UNANCHOR(user)
 				return TRUE
 			if(!tool.tool_start_check(user, 1))
 				return TRUE
-			USE_FEEDBACK_DECONSTRUCT_START
+			USE_FEEDBACK_DECONSTRUCT_START(user)
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return TRUE
 			new /obj/item/stack/material/plasteel(loc, 4)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -353,11 +353,11 @@ var/global/list/empty_playable_ai_cores = list()
 	if (tool.tool_behaviour == TOOL_WELDER)
 		if (state == STATE_FRAME)
 			if(anchored)
-				balloon_alert(user, "необходимо открутить от пола!")
+				USE_FEEDBACK_NEED_UNANCHOR
 				return TRUE
 			if(!tool.tool_start_check(user, 1))
 				return TRUE
-			balloon_alert(user, "разбор")
+			USE_FEEDBACK_DECONSTRUCT_START
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return TRUE
 			new /obj/item/stack/material/plasteel(loc, 4)

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -353,14 +353,11 @@ var/global/list/empty_playable_ai_cores = list()
 	if (tool.tool_behaviour == TOOL_WELDER)
 		if (state == STATE_FRAME)
 			if(anchored)
-				USE_FEEDBACK_FAILURE("[src] needs to be unanchored from the floor before you can dismantle it with [tool].")
+				balloon_alert(user, "необходимо открутить от пола!")
 				return TRUE
 			if(!tool.tool_start_check(user, 1))
 				return TRUE
-			user.visible_message(
-				SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
-				SPAN_NOTICE("You start dismantling [src] with [tool].")
-			)
+			balloon_alert(user, "начало разбора")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return TRUE
 			new /obj/item/stack/material/plasteel(loc, 4)
@@ -368,7 +365,7 @@ var/global/list/empty_playable_ai_cores = list()
 				SPAN_NOTICE("[user] dismantles [src] with [tool]."),
 				SPAN_NOTICE("You dismantle [src] with [tool].")
 			)
-			qdel_self()
+			qdel(src)
 			return TRUE
 
 	// Wirecutters

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -357,7 +357,7 @@ var/global/list/empty_playable_ai_cores = list()
 				return TRUE
 			if(!tool.tool_start_check(user, 1))
 				return TRUE
-			balloon_alert(user, "начало разбора")
+			balloon_alert(user, "разбор")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return TRUE
 			new /obj/item/stack/material/plasteel(loc, 4)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1033,11 +1033,13 @@ About the new airlock wires panel:
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
+	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
 	user.visible_message(SPAN_WARNING("[user] begins welding [src] [welded ? "open" : "closed"]!"),
 						SPAN_NOTICE("You begin welding [src] [welded ? "open" : "closed"]."))
 	if(!tool.use_as_tool(src, user, (rand(3, 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || repairing || operating == DOOR_OPERATING_YES || !density)
 		return
 	welded = !welded
+	balloon_alert(user, "[welded ? "заварено" : "отварено"]")
 	update_icon()
 
 /obj/machinery/door/airlock/use_tool(obj/item/C, mob/living/user, list/click_params)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1037,8 +1037,7 @@ About the new airlock wires panel:
 	if(!tool.use_as_tool(src, user, (rand(3, 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || repairing || operating == DOOR_OPERATING_YES || !density)
 		return
 	welded = !welded
-	user.visible_message(SPAN_NOTICE("[user] welds [src] [welded ? "closed" : "open"]!"),
-						SPAN_NOTICE("You weld [src] [welded ? "closed" : "open"]."))
+	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
 	update_icon()
 
 /obj/machinery/door/airlock/use_tool(obj/item/C, mob/living/user, list/click_params)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1033,13 +1033,12 @@ About the new airlock wires panel:
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
-	user.visible_message(SPAN_WARNING("[user] begins welding [src] [welded ? "open" : "closed"]!"),
-						SPAN_NOTICE("You begin welding [src] [welded ? "open" : "closed"]."))
+	USE_FEEDBACK_WELD_UNWELD(welded)
 	if(!tool.use_as_tool(src, user, (rand(3, 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || repairing || operating == DOOR_OPERATING_YES || !density)
 		return
 	welded = !welded
-	balloon_alert(user, "[welded ? "заварено" : "отварено"]")
+	user.visible_message(SPAN_NOTICE("[user] welds [src] [welded ? "closed" : "open"]!"),
+						SPAN_NOTICE("You weld [src] [welded ? "closed" : "open"]."))
 	update_icon()
 
 /obj/machinery/door/airlock/use_tool(obj/item/C, mob/living/user, list/click_params)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1033,11 +1033,11 @@ About the new airlock wires panel:
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_WELD_UNWELD(welded)
+	USE_FEEDBACK_WELD_UNWELD(user, welded)
 	if(!tool.use_as_tool(src, user, (rand(3, 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || repairing || operating == DOOR_OPERATING_YES || !density)
 		return
 	welded = !welded
-	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(user, welded)
 	update_icon()
 
 /obj/machinery/door/airlock/use_tool(obj/item/C, mob/living/user, list/click_params)

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -65,14 +65,14 @@
 /obj/item/airlock_brace/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	restore_health(rand(75, 150))
 
 /obj/item/airlock_brace/attackby(obj/item/item, mob/living/user)

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -69,7 +69,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -65,14 +65,14 @@
 /obj/item/airlock_brace/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		balloon_alert(user, "нет повреждений")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	restore_health(rand(75, 150))
 
 /obj/item/airlock_brace/attackby(obj/item/item, mob/living/user)

--- a/code/game/machinery/doors/braces.dm
+++ b/code/game/machinery/doors/braces.dm
@@ -65,20 +65,14 @@
 /obj/item/airlock_brace/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		to_chat(user, SPAN_NOTICE("[src] does not require repairs."))
+		balloon_alert(user, "нет повреждений")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_ITALIC("[user] begins repairing damage on [src]."),
-		SPAN_ITALIC("You begin repairing damage on the [src].")
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	user.visible_message(
-		SPAN_ITALIC("[user] repairs damage on [src]."),
-		SPAN_ITALIC("You repair damage on the [src].")
-	)
+	USE_FEEDBACK_REPAIR_GENERAL
 	restore_health(rand(75, 150))
 
 /obj/item/airlock_brace/attackby(obj/item/item, mob/living/user)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -207,7 +207,7 @@
 		return
 	if(!tool.tool_start_check(user, 2))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, (0.5 * repairing.amount) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !repairing || !density)
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -203,14 +203,14 @@
 		return
 	. = ITEM_INTERACT_SUCCESS
 	if(!density)
-		balloon_alert(user, "необходимо закрыть!")
+		balloon_alert(user, "нужно закрыть!")
 		return
 	if(!tool.tool_start_check(user, 2))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, (0.5 * repairing.amount) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !repairing || !density)
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	restore_health(repairing.amount * DOOR_REPAIR_AMOUNT)
 	update_icon()
 	qdel(repairing)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -203,14 +203,14 @@
 		return
 	. = ITEM_INTERACT_SUCCESS
 	if(!density)
-		to_chat(user, SPAN_WARNING("[src] must be closed before you can repair it."))
+		balloon_alert(user, "необходимо закрыть!")
 		return
 	if(!tool.tool_start_check(user, 2))
 		return
-	to_chat(user, SPAN_NOTICE("You start to fix dents and weld [repairing] into place."))
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, (0.5 * repairing.amount) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !repairing || !density)
 		return
-	to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+	USE_FEEDBACK_REPAIR_GENERAL
 	restore_health(repairing.amount * DOOR_REPAIR_AMOUNT)
 	update_icon()
 	qdel(repairing)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -207,10 +207,10 @@
 		return
 	if(!tool.tool_start_check(user, 2))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, (0.5 * repairing.amount) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !repairing || !density)
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	restore_health(repairing.amount * DOOR_REPAIR_AMOUNT)
 	update_icon()
 	qdel(repairing)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -277,11 +277,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 2))
 		return
-	user.visible_message(
-		SPAN_WARNING("[user] starts [!blocked ? "welding [src] shut" : "cutting open [src]"]."),
-		SPAN_DANGER("You start [!blocked ? "welding [src] closed" : "cutting open [src]"]."),
-		SPAN_ITALIC("You hear welding.")
-	)
+	balloon_alert(user, "[blocked ? "отваривание" : "заваривание"]")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	blocked = !blocked

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -277,11 +277,11 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 2))
 		return
-	USE_FEEDBACK_WELD_UNWELD(blocked)
+	USE_FEEDBACK_WELD_UNWELD(user, blocked)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	blocked = !blocked
-	USE_FEEDBACK_WELD_UNWELD_FINISH(blocked)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(user, blocked)
 	update_icon()
 
 /obj/machinery/door/firedoor/use_tool(obj/item/C, mob/living/user, list/click_params)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -277,7 +277,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 2))
 		return
-	balloon_alert(user, "[blocked ? "отваривание" : "заваривание"]")
+	USE_FEEDBACK_WELD_UNWELD(blocked)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	blocked = !blocked

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -281,11 +281,7 @@
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	blocked = !blocked
-	user.visible_message(
-		SPAN_DANGER("[user] [blocked ? "welds [src] shut" : "cuts open [src]"]."),
-		SPAN_DANGER("You [blocked ? "weld shut" : "undo the welds on"] [src]."),
-		SPAN_ITALIC("You hear welding.")
-	)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(blocked)
 	update_icon()
 
 /obj/machinery/door/firedoor/use_tool(obj/item/C, mob/living/user, list/click_params)

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -35,7 +35,7 @@
 
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало разбора")
+	balloon_alert(user, "разбор")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/item/stack/material/steel/stack = new (loc, 4)

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -30,11 +30,11 @@
 /obj/structure/firedoor_assembly/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(anchored)
-		USE_FEEDBACK_NEED_UNANCHOR
+		USE_FEEDBACK_NEED_UNANCHOR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_DECONSTRUCT_START
+	USE_FEEDBACK_DECONSTRUCT_START(user)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/item/stack/material/steel/stack = new (loc, 4)

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -30,12 +30,12 @@
 /obj/structure/firedoor_assembly/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(anchored)
-		balloon_alert(user, "необходимо открутить от пола!")
+		USE_FEEDBACK_NEED_UNANCHOR
 		return
 
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "разбор")
+	USE_FEEDBACK_DECONSTRUCT_START
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/item/stack/material/steel/stack = new (loc, 4)

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -30,15 +30,12 @@
 /obj/structure/firedoor_assembly/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(anchored)
-		USE_FEEDBACK_FAILURE("[src] needs to be unanchored before you can dismantle it.")
+		balloon_alert(user, "необходимо открутить от пола!")
 		return
 
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
-		SPAN_NOTICE("You start dismantling [src] with [tool].")
-	)
+	balloon_alert(user, "начало разбора")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/item/stack/material/steel/stack = new (loc, 4)

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -32,7 +32,6 @@
 	if(anchored)
 		USE_FEEDBACK_NEED_UNANCHOR
 		return
-
 	if(!tool.tool_start_check(user, 1))
 		return
 	USE_FEEDBACK_DECONSTRUCT_START

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -55,7 +55,7 @@ var/global/list/floor_light_cache = list()
 /obj/machinery/floor_light/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health_damaged() || MACHINE_IS_BROKEN(src))
-		balloon_alert(user, "начало ремонта")
+		balloon_alert(user, "ремонт")
 		if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
 		USE_FEEDBACK_REPAIR_GENERAL

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -55,9 +55,10 @@ var/global/list/floor_light_cache = list()
 /obj/machinery/floor_light/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health_damaged() || MACHINE_IS_BROKEN(src))
+		balloon_alert(user, "начало ремонта")
 		if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		visible_message(SPAN_NOTICE("[user] has repaired [src]."))
+		USE_FEEDBACK_REPAIR_GENERAL
 		set_broken(FALSE)
 		revive_health()
 

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -55,10 +55,10 @@ var/global/list/floor_light_cache = list()
 /obj/machinery/floor_light/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health_damaged() || MACHINE_IS_BROKEN(src))
-		balloon_alert(user, "ремонт")
+		USE_FEEDBACK_REPAIR_START
 		if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		USE_FEEDBACK_REPAIR_GENERAL
+		USE_FEEDBACK_REPAIR_FINISH
 		set_broken(FALSE)
 		revive_health()
 

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -55,10 +55,10 @@ var/global/list/floor_light_cache = list()
 /obj/machinery/floor_light/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health_damaged() || MACHINE_IS_BROKEN(src))
-		USE_FEEDBACK_REPAIR_START
+		USE_FEEDBACK_REPAIR_START(user)
 		if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		USE_FEEDBACK_REPAIR_FINISH
+		USE_FEEDBACK_REPAIR_FINISH(user)
 		set_broken(FALSE)
 		revive_health()
 

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -663,10 +663,10 @@ var/global/list/turret_icons
 			else if(I.tool_behaviour == TOOL_WELDER)
 				if(!I.tool_start_check(user, 5))
 					return TRUE
+				balloon_alert(user, "снятие брони")
 				if(!I.use_as_tool(src, user, 2 SECONDS, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 					return TRUE
 				build_step = 1
-				to_chat(user, "You remove the turret's interior metal armor.")
 				new /obj/item/stack/material/steel( loc, 2)
 				return TRUE
 
@@ -729,10 +729,10 @@ var/global/list/turret_icons
 			if(I.tool_behaviour == TOOL_WELDER)
 				if(!I.tool_start_check(user, 5))
 					return TRUE
+				balloon_alert(user, "приваривание брони")
 				if(!I.use_as_tool(src, user, 3 SECONDS, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 					return TRUE
 				build_step = 8
-				to_chat(user, SPAN_NOTICE("You weld the turret's armor down."))
 
 				//The final step: create a full turret
 				var/obj/machinery/porta_turret/Turret = new target_type(loc)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,14 +14,11 @@
 	if(damaged)
 		if(!tool.tool_start_check(user, 10))
 			return
-		user.visible_message(
-			SPAN_NOTICE("[user] begins to repair [src]."),
-			SPAN_NOTICE("You begin repairing [src].")
-		)
+		balloon_alert(user, "начало ремонта")
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 10, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
+		USE_FEEDBACK_REPAIR_GENERAL
 		damaged = 0
-		user.visible_message("[user] repairs [src].", "You repair [src].")
 
 /obj/machinery/self_destruct/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/nuclear_cylinder))

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,10 +14,10 @@
 	if(damaged)
 		if(!tool.tool_start_check(user, 10))
 			return
-		USE_FEEDBACK_REPAIR_START
+		USE_FEEDBACK_REPAIR_START(user)
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 10, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		USE_FEEDBACK_REPAIR_FINISH
+		USE_FEEDBACK_REPAIR_FINISH(user)
 		damaged = 0
 
 /obj/machinery/self_destruct/use_tool(obj/item/W, mob/living/user, list/click_params)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,10 +14,10 @@
 	if(damaged)
 		if(!tool.tool_start_check(user, 10))
 			return
-		balloon_alert(user, "ремонт")
+		USE_FEEDBACK_REPAIR_START
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 10, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		USE_FEEDBACK_REPAIR_GENERAL
+		USE_FEEDBACK_REPAIR_FINISH
 		damaged = 0
 
 /obj/machinery/self_destruct/use_tool(obj/item/W, mob/living/user, list/click_params)

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -14,7 +14,7 @@
 	if(damaged)
 		if(!tool.tool_start_check(user, 10))
 			return
-		balloon_alert(user, "начало ремонта")
+		balloon_alert(user, "ремонт")
 		if(!tool.use_as_tool(src, user, 10 SECONDS, 10, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
 		USE_FEEDBACK_REPAIR_GENERAL

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -44,14 +44,13 @@
 /obj/item/stack/material/rods/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(material.ignition_point)
-		to_chat(user, SPAN_WARNING("You can't weld this material into sheets."))
+		balloon_alert(user, "невозможно превратить в листы!")
 		return
 	if(!can_use(2))
-		to_chat(user, SPAN_WARNING("You need at least two rods to do this."))
+		balloon_alert(user, "нужно два стержня минимум!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-
 	var/obj/item/stack/material/new_item = material.place_sheet(usr.loc)
 	new_item.add_to_stacks(usr)
 	user.visible_message(

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -170,7 +170,7 @@ var/global/list/tank_gauge_cache = list()
 	. = ITEM_INTERACT_SUCCESS
 	var/obj/item/weldingtool/WT = tool
 	if(GET_FLAGS(tank_flags, TANK_FLAG_FORCED))
-		balloon_alert(user, "необходимо закрыть клапан!")
+		balloon_alert(user, "нужно закрыть клапан!")
 		return
 	if(GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
 		balloon_alert(user, "клапан уже заварен!")

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -170,16 +170,16 @@ var/global/list/tank_gauge_cache = list()
 	. = ITEM_INTERACT_SUCCESS
 	var/obj/item/weldingtool/WT = tool
 	if(GET_FLAGS(tank_flags, TANK_FLAG_FORCED))
-		to_chat(user, SPAN_WARNING("[src]'s emergency relief valve must be closed before you can weld it shut!"))
+		balloon_alert(user, "необходимо закрыть клапан!")
 		return
 	if(GET_FLAGS(tank_flags, TANK_FLAG_WELDED))
-		to_chat(user, SPAN_NOTICE("The emergency pressure relief valve has already been welded."))
+		balloon_alert(user, "клапан уже заварен!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
 
 	add_fingerprint(user)
-	to_chat(user, SPAN_NOTICE("You begin welding the [src] emergency pressure relief valve."))
+	balloon_alert(user, "заваривание клапона")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_PUBLIC_UNIQUE))
 		GLOB.bombers += "[key_name(user)] attempted to weld a [src]. [air_contents.temperature-T0C]"
 		log_and_message_admins("attempted to weld a [src]. [air_contents.temperature-T0C]", user)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -179,7 +179,7 @@ var/global/list/tank_gauge_cache = list()
 		return
 
 	add_fingerprint(user)
-	balloon_alert(user, "заваривание клапона")
+	balloon_alert(user, "заваривание клапана")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_PUBLIC_UNIQUE))
 		GLOB.bombers += "[key_name(user)] attempted to weld a [src]. [air_contents.temperature-T0C]"
 		log_and_message_admins("attempted to weld a [src]. [air_contents.temperature-T0C]", user)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -174,7 +174,7 @@
 /// If welding tool ran out of fuel during a construction task, construction fails.
 /obj/item/weldingtool/tool_use_check(mob/living/user, amount)
 	if(!isOn() || !check_fuel())
-		to_chat(user, SPAN_WARNING("[src] has to be on to complete this task!"))
+		balloon_alert(user, "нужен включенный аппарат!")
 		return FALSE
 
 	if(get_fuel() >= amount)
@@ -184,7 +184,7 @@
 			addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_icon)), 5)
 		return TRUE
 	else
-		to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task!"))
+		balloon_alert(user, "нужно больше топлива!")
 		return FALSE
 
 /obj/item/weldingtool/proc/burn_fuel(amount)

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -23,10 +23,10 @@
 	if(!istype(T))
 		return
 	if(!T.tank)
-		to_chat(user, SPAN_WARNING("[T] has no tank attached!"))
+		balloon_alert(user, "нет баллона!")
 		return
 	if(!T.tank.can_refuel)
-		to_chat(user, SPAN_WARNING("[T]'s [T.tank.name] does not have a refuelling port."))
+		balloon_alert(user, "невозможно заправить этот баллон!")
 		return
 	if(T.welding)
 		if(user.a_intent == I_HURT)
@@ -43,9 +43,9 @@
 			to_chat(user, SPAN_WARNING("You need to turn [T] off before you can refuel it. Or use harm intent if you're suicidal."))
 			return
 	if(!reagents.trans_to_obj(T.tank, T.tank.max_fuel))
-		to_chat(user, SPAN_WARNING("[T]'s [T.tank.name] is already full."))
+		balloon_alert(user, "баллон уже полон!")
 		return
-	to_chat(user, SPAN_NOTICE("You refill [T] with [src]."))
+	balloon_alert(user, "баллон пополнен")
 	playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
 
 /obj/item/storage/backpack/weldpack/use_tool(obj/item/W, mob/living/user, list/click_params)

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -63,8 +63,6 @@
 		attack_hand(user)
 
 /obj/structure/catwalk/proc/deconstruct(mob/user)
-	playsound(src, 'sound/items/Welder.ogg', 100, 1)
-	to_chat(user, SPAN_NOTICE("Slicing [src] joints ..."))
 	new /obj/item/stack/material/rods(src.loc)
 	new /obj/item/stack/material/rods(src.loc)
 	//Lattice would delete itself, but let's save ourselves a new obj

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -310,6 +310,7 @@
 
 /obj/structure/closet/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
+	balloon_alert(user, "начало разбора")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	slice_into_parts(tool, user)
@@ -319,10 +320,11 @@
 		return
 	. = ITEM_INTERACT_SUCCESS
 	if(!HAS_FLAGS(setup, CLOSET_CAN_BE_WELDED))
-		USE_FEEDBACK_FAILURE("[src] can't be welded shut.")
+		balloon_alert(user, "неозможно заварить!")
 		return
 	if(user.loc == src)
 		return
+	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -310,7 +310,7 @@
 
 /obj/structure/closet/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
-	USE_FEEDBACK_DECONSTRUCT_START
+	USE_FEEDBACK_DECONSTRUCT_START(user)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	slice_into_parts(tool, user)
@@ -324,12 +324,12 @@
 		return
 	if(user.loc == src)
 		return
-	USE_FEEDBACK_WELD_UNWELD(welded)
+	USE_FEEDBACK_WELD_UNWELD(user, welded)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
 	update_icon()
-	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(user, welded)
 
 /obj/structure/closet/use_tool(obj/item/tool, mob/user, list/click_params)
 	// General Action - Place item in closet, if open.

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -329,10 +329,7 @@
 		return
 	welded = !welded
 	update_icon()
-	user.visible_message(
-		SPAN_WARNING("[user] [welded ? "welds" : "unwelds"] [src] with [tool]."),
-		SPAN_WARNING("You [welded ? "weld" : "unweld"] [src] with [tool].")
-	)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
 
 /obj/structure/closet/use_tool(obj/item/tool, mob/user, list/click_params)
 	// General Action - Place item in closet, if open.

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -310,7 +310,7 @@
 
 /obj/structure/closet/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
-	balloon_alert(user, "начало разбора")
+	balloon_alert(user, "разбор")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	slice_into_parts(tool, user)

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -310,7 +310,7 @@
 
 /obj/structure/closet/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
-	balloon_alert(user, "разбор")
+	USE_FEEDBACK_DECONSTRUCT_START
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	slice_into_parts(tool, user)
@@ -320,11 +320,11 @@
 		return
 	. = ITEM_INTERACT_SUCCESS
 	if(!HAS_FLAGS(setup, CLOSET_CAN_BE_WELDED))
-		balloon_alert(user, "неозможно заварить!")
+		balloon_alert(user, "невозможно заварить!")
 		return
 	if(user.loc == src)
 		return
-	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
+	USE_FEEDBACK_WELD_UNWELD(welded)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -205,11 +205,11 @@
 
 	// Dismantle assembly
 	if(anchored)
-		USE_FEEDBACK_NEED_UNANCHOR
+		USE_FEEDBACK_NEED_UNANCHOR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_DECONSTRUCT_START
+	USE_FEEDBACK_DECONSTRUCT_START(user)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || anchored)
 		return
 	var/obj/item/stack/material/steel/stack = new(loc, 4)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -209,7 +209,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало разбора")
+	balloon_alert(user, "разбор")
 	user.visible_message(
 		SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
 		SPAN_NOTICE("You start dismantling [src] with [tool].")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -210,10 +210,6 @@
 	if(!tool.tool_start_check(user, 1))
 		return
 	USE_FEEDBACK_DECONSTRUCT_START
-	user.visible_message(
-		SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
-		SPAN_NOTICE("You start dismantling [src] with [tool].")
-	)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || anchored)
 		return
 	var/obj/item/stack/material/steel/stack = new(loc, 4)

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -185,10 +185,7 @@
 		var/glass_noun = istext(glass) ? "[glass] plating" : "glass panel"
 		if(!tool.tool_start_check(user, 1))
 			return
-		user.visible_message(
-			SPAN_NOTICE("[user] starts welding [src]'s [glass_noun] off with [tool]."),
-			SPAN_NOTICE("You start welding [src]'s [glass_noun] off with [tool].")
-		)
+		balloon_alert(user, "отваривание [glass_noun]")
 		if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !glass)
 			return
 		var/obj/item/stack/material/stack
@@ -208,10 +205,11 @@
 
 	// Dismantle assembly
 	if(anchored)
-		USE_FEEDBACK_FAILURE("[src] must be unanchored before you can dismantle it.")
+		balloon_alert(user, "необходимо открепить от пола!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
+	balloon_alert(user, "начало разбора")
 	user.visible_message(
 		SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
 		SPAN_NOTICE("You start dismantling [src] with [tool].")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -205,11 +205,11 @@
 
 	// Dismantle assembly
 	if(anchored)
-		balloon_alert(user, "необходимо открепить от пола!")
+		USE_FEEDBACK_NEED_UNANCHOR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "разбор")
+	USE_FEEDBACK_DECONSTRUCT_START
 	user.visible_message(
 		SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
 		SPAN_NOTICE("You start dismantling [src] with [tool].")

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -29,7 +29,7 @@
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
-	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(user, welded)
 	update_icon()
 
 

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -29,11 +29,7 @@
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
-	balloon_alert(user, "[welded ? "заварено" : "отварено"]")
-	user.visible_message(
-		SPAN_NOTICE("[user] [welded ? "un" : "welds"] [src] with [tool]."),
-		SPAN_NOTICE("You [welded ? "un" : "weld"] [src] with [tool].")
-	)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
 	update_icon()
 
 

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -29,6 +29,7 @@
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
+	balloon_alert(user, "[welded ? "заварено" : "отварено"]")
 	user.visible_message(
 		SPAN_NOTICE("[user] [welded ? "un" : "welds"] [src] with [tool]."),
 		SPAN_NOTICE("You [welded ? "un" : "weld"] [src] with [tool].")

--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -51,8 +51,8 @@
 
 /obj/structure/lattice/proc/deconstruct(mob/user, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] slices \the [src] apart with \a [tool]."),
-		SPAN_NOTICE("You \the [src] apart with \a [tool].")
+		SPAN_NOTICE("[user] slices [src] apart with [tool]."),
+		SPAN_NOTICE("You [src] apart with [tool].")
 	)
 	var/obj/item/stack/material/rods/rods = new(loc, 1, material.name)
 	transfer_fingerprints_to(rods)

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -292,15 +292,15 @@
 	. = ITEM_INTERACT_SUCCESS
 	// Welding Tool - Repair
 	if(!health_damaged())
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !health_damaged())
 		return
 	restore_health(get_max_health() / 5)
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 
 /obj/structure/railing/can_climb(mob/living/user, post_climb_check=FALSE, check_silicon=TRUE)
 	. = ..()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -292,22 +292,15 @@
 	. = ITEM_INTERACT_SUCCESS
 	// Welding Tool - Repair
 	if(!health_damaged())
-		USE_FEEDBACK_FAILURE("[src] doesn't require repairs.")
+		balloon_alert(user, "нет повреждений!")
 		return
-
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts repairing [src] with [tool]."),
-		SPAN_NOTICE("You start repairing [src] with [tool].")
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !health_damaged())
 		return
 	restore_health(get_max_health() / 5)
-	user.visible_message(
-		SPAN_NOTICE("[user] repairs [src] with [tool]."),
-		SPAN_NOTICE("You repair [src] with [tool].")
-	)
+	USE_FEEDBACK_REPAIR_GENERAL
 
 /obj/structure/railing/can_climb(mob/living/user, post_climb_check=FALSE, check_silicon=TRUE)
 	. = ..()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -292,15 +292,15 @@
 	. = ITEM_INTERACT_SUCCESS
 	// Welding Tool - Repair
 	if(!health_damaged())
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !health_damaged())
 		return
 	restore_health(get_max_health() / 5)
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 
 /obj/structure/railing/can_climb(mob/living/user, post_climb_check=FALSE, check_silicon=TRUE)
 	. = ..()

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -296,7 +296,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !health_damaged())
 		return
 	restore_health(get_max_health() / 5)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -151,17 +151,14 @@
 /obj/structure/windoor_assembly/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(state != WINDOOR_STATE_FRAME)
-		USE_FEEDBACK_FAILURE("[src]'s wiring must be removed before you can dismantle it.")
+		balloon_alert(user, "необходимо убрать проводку!")
 		return
 	if(anchored)
-		USE_FEEDBACK_FAILURE("[src] needs to be unanchored before you can dismantle it.")
+		balloon_alert(user, "необходимо открепить от пола!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts dismantling [src] with [tool]."),
-		SPAN_NOTICE("You start dismantling [src] with [tool].")
-	)
+	balloon_alert(user, "начало разбора")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || state != WINDOOR_STATE_FRAME || anchored)
 		return
 	var/obj/item/stack/material/glass/reinforced/glass = new(loc, 5)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -151,14 +151,14 @@
 /obj/structure/windoor_assembly/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(state != WINDOOR_STATE_FRAME)
-		balloon_alert(user, "необходимо убрать проводку!")
+		balloon_alert(user, "нужно убрать проводку!")
 		return
 	if(anchored)
-		balloon_alert(user, "необходимо открепить от пола!")
+		USE_FEEDBACK_NEED_UNANCHOR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "разбор")
+	USE_FEEDBACK_DECONSTRUCT_START
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || state != WINDOOR_STATE_FRAME || anchored)
 		return
 	var/obj/item/stack/material/glass/reinforced/glass = new(loc, 5)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -154,11 +154,11 @@
 		balloon_alert(user, "нужно убрать проводку!")
 		return
 	if(anchored)
-		USE_FEEDBACK_NEED_UNANCHOR
+		USE_FEEDBACK_NEED_UNANCHOR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_DECONSTRUCT_START
+	USE_FEEDBACK_DECONSTRUCT_START(user)
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || state != WINDOOR_STATE_FRAME || anchored)
 		return
 	var/obj/item/stack/material/glass/reinforced/glass = new(loc, 5)

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -158,7 +158,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало разбора")
+	balloon_alert(user, "разбор")
 	if(!tool.use_as_tool(src, user, 4 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || state != WINDOOR_STATE_FRAME || anchored)
 		return
 	var/obj/item/stack/material/glass/reinforced/glass = new(loc, 5)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -373,14 +373,14 @@
 /obj/structure/window/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!repair_pending)
 		balloon_alert(user, "нужно установить [get_material_display_name()]!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	restore_health(repair_pending)
 	repair_pending = 0
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -373,19 +373,16 @@
 /obj/structure/window/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		USE_FEEDBACK_FAILURE("[src] does not need repairs.")
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!repair_pending)
-		USE_FEEDBACK_FAILURE("[src] needs some [get_material_display_name()] applied before you can weld it.")
+		balloon_alert(user, "необходимо установить [get_material_display_name()]!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
+	USE_FEEDBACK_REPAIR_GENERAL
 	restore_health(repair_pending)
 	repair_pending = 0
-	user.visible_message(
-		SPAN_NOTICE("[user] welds [src]'s [material] into place with [tool]."),
-		SPAN_NOTICE("You weld [src]'s [material] into place with [tool].")
-	)
 
 /obj/structure/window/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Cable Coil - Polarize window

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -373,14 +373,14 @@
 /obj/structure/window/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!repair_pending)
-		balloon_alert(user, "необходимо установить [get_material_display_name()]!")
+		balloon_alert(user, "нужно установить [get_material_display_name()]!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	restore_health(repair_pending)
 	repair_pending = 0
 

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -171,7 +171,7 @@
 			if(broken || burnt)
 				if(!C.use_as_tool(src, user, amount = 2, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 					return TRUE
-				USE_FEEDBACK_REPAIR_FINISH
+				USE_FEEDBACK_REPAIR_FINISH(user)
 				playsound(src, 'sound/items/Welder.ogg', 80, 1)
 				icon_state = "plating"
 				burnt = null

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -171,7 +171,7 @@
 			if(broken || burnt)
 				if(!C.use_as_tool(src, user, amount = 2, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 					return TRUE
-				USE_FEEDBACK_REPAIR_GENERAL
+				USE_FEEDBACK_REPAIR_FINISH
 				playsound(src, 'sound/items/Welder.ogg', 80, 1)
 				icon_state = "plating"
 				burnt = null

--- a/code/game/turfs/simulated/floor_attackby.dm
+++ b/code/game/turfs/simulated/floor_attackby.dm
@@ -171,7 +171,7 @@
 			if(broken || burnt)
 				if(!C.use_as_tool(src, user, amount = 2, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 					return TRUE
-				to_chat(user, SPAN_NOTICE("You fix some dents on the broken plating."))
+				USE_FEEDBACK_REPAIR_GENERAL
 				playsound(src, 'sound/items/Welder.ogg', 80, 1)
 				icon_state = "plating"
 				burnt = null

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -190,10 +190,11 @@
 	if(damage && W.tool_behaviour == TOOL_WELDER)
 		if(!W.tool_start_check(user, 2))
 			return
+		balloon_alert(user, "начало ремонта")
 		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
 		if(!W.use_as_tool(src, user, (max(5, damage / 5)) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+		USE_FEEDBACK_REPAIR_GENERAL
 		restore_health(damage)
 		return TRUE
 
@@ -229,7 +230,7 @@
 			strict_timer_flags = TRUE
 
 		if(dismantle_verb)
-			to_chat(user, SPAN_NOTICE("You begin [dismantle_verb] through the outer plating."))
+			balloon_alert(user, "начало разбора")
 			if(dismantle_sound)
 				playsound(src, dismantle_sound, 100, 1)
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -190,11 +190,11 @@
 	if(damage && W.tool_behaviour == TOOL_WELDER)
 		if(!W.tool_start_check(user, 2))
 			return
-		USE_FEEDBACK_REPAIR_START
+		USE_FEEDBACK_REPAIR_START(user)
 		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
 		if(!W.use_as_tool(src, user, (max(5, damage / 5)) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		USE_FEEDBACK_REPAIR_FINISH
+		USE_FEEDBACK_REPAIR_FINISH(user)
 		restore_health(damage)
 		return TRUE
 
@@ -230,7 +230,7 @@
 			strict_timer_flags = TRUE
 
 		if(dismantle_verb)
-			USE_FEEDBACK_DECONSTRUCT_START
+			USE_FEEDBACK_DECONSTRUCT_START(user)
 			if(dismantle_sound)
 				playsound(src, dismantle_sound, 100, 1)
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -190,11 +190,11 @@
 	if(damage && W.tool_behaviour == TOOL_WELDER)
 		if(!W.tool_start_check(user, 2))
 			return
-		balloon_alert(user, "ремонт")
+		USE_FEEDBACK_REPAIR_START
 		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
 		if(!W.use_as_tool(src, user, (max(5, damage / 5)) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
-		USE_FEEDBACK_REPAIR_GENERAL
+		USE_FEEDBACK_REPAIR_FINISH
 		restore_health(damage)
 		return TRUE
 
@@ -230,7 +230,7 @@
 			strict_timer_flags = TRUE
 
 		if(dismantle_verb)
-			balloon_alert(user, "разбор")
+			USE_FEEDBACK_DECONSTRUCT_START
 			if(dismantle_sound)
 				playsound(src, dismantle_sound, 100, 1)
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -190,7 +190,7 @@
 	if(damage && W.tool_behaviour == TOOL_WELDER)
 		if(!W.tool_start_check(user, 2))
 			return
-		balloon_alert(user, "начало ремонта")
+		balloon_alert(user, "ремонт")
 		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
 		if(!W.use_as_tool(src, user, (max(5, damage / 5)) SECONDS, 2, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 			return
@@ -230,7 +230,7 @@
 			strict_timer_flags = TRUE
 
 		if(dismantle_verb)
-			balloon_alert(user, "начало разбора")
+			balloon_alert(user, "разбор")
 			if(dismantle_sound)
 				playsound(src, dismantle_sound, 100, 1)
 

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -305,7 +305,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
+	USE_FEEDBACK_WELD_UNWELD(welded)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -305,12 +305,12 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_WELD_UNWELD(welded)
+	USE_FEEDBACK_WELD_UNWELD(user, welded)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
 	update_icon()
-	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(user, welded)
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/get_console_data()
 	. = list()

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -305,7 +305,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	to_chat(user, SPAN_NOTICE("Now welding [src]."))
+	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -310,10 +310,7 @@
 		return
 	welded = !welded
 	update_icon()
-	user.visible_message(
-		SPAN_NOTICE("[user] [welded ? "welds [src] shut" : "unwelds [src]"]."), \
-		SPAN_NOTICE("You [welded ? "weld [src] shut" : "unweld [src]"]."), \
-		"You hear welding.")
+	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
 
 /obj/machinery/atmospherics/unary/vent_pump/proc/get_console_data()
 	. = list()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -212,10 +212,7 @@
 		return
 	welded = !welded
 	update_icon()
-	user.visible_message(
-		SPAN_NOTICE("[user] [welded ? "welds [src] shut" : "unwelds [src]"]."), \
-		SPAN_NOTICE("You [welded ? "weld [src] shut" : "unweld [src]"]."), \
-		"You hear welding.")
+	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
 
 /obj/machinery/atmospherics/unary/vent_scrubber/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -207,12 +207,11 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	to_chat(user, SPAN_NOTICE("Now welding [src]."))
+	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
 	update_icon()
-	playsound(src, 'sound/items/Welder2.ogg', 50, 1)
 	user.visible_message(
 		SPAN_NOTICE("[user] [welded ? "welds [src] shut" : "unwelds [src]"]."), \
 		SPAN_NOTICE("You [welded ? "weld [src] shut" : "unweld [src]"]."), \

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -207,12 +207,12 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_WELD_UNWELD(welded)
+	USE_FEEDBACK_WELD_UNWELD(user, welded)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded
 	update_icon()
-	USE_FEEDBACK_WELD_UNWELD_FINISH(welded)
+	USE_FEEDBACK_WELD_UNWELD_FINISH(user, welded)
 
 /obj/machinery/atmospherics/unary/vent_scrubber/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -207,7 +207,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "[welded ? "отваривание" : "заваривание"]")
+	USE_FEEDBACK_WELD_UNWELD(welded)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded = !welded

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -190,11 +190,11 @@
 			balloon_alert(user, "нужно снять с себя!")
 			return
 	if(brute_damage <= 0)
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.use_as_tool(src, user, amount = 5, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	repair_breaches(DAMAGE_BRUTE, 3, user)
 
 /obj/item/clothing/suit/space/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -187,13 +187,14 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.wear_suit == src)
-			to_chat(user, SPAN_WARNING("You cannot repair [src] while it is being worn."))
+			balloon_alert(user, "необходимо снять с себя!")
 			return
 	if(brute_damage <= 0)
-		to_chat(user, "There is no structural damage on [src] to repair.")
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 5, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
+	USE_FEEDBACK_REPAIR_GENERAL
 	repair_breaches(DAMAGE_BRUTE, 3, user)
 
 /obj/item/clothing/suit/space/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -187,14 +187,14 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(H.wear_suit == src)
-			balloon_alert(user, "необходимо снять с себя!")
+			balloon_alert(user, "нужно снять с себя!")
 			return
 	if(brute_damage <= 0)
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.use_as_tool(src, user, amount = 5, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	repair_breaches(DAMAGE_BRUTE, 3, user)
 
 /obj/item/clothing/suit/space/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -135,20 +135,17 @@
 
 /obj/item/mech_component/proc/repair_brute_generic(obj/item/tool, mob/user)
 	if(!brute_damage)
-		to_chat(user, SPAN_NOTICE("You inspect [src] but find nothing to weld."))
+		balloon_alert(user, "нет физических повреждений!")
 		return
 	var/amount = (SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION)
 	if(!tool.tool_start_check(user, amount))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] begins welding the damage on [src]..."),
-		SPAN_NOTICE("You begin welding the damage on [src]...")
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 1 SECONDS, amount, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !brute_damage)
 		return
 	var/repair_value = 10 * max(user.get_skill_value(SKILL_CONSTRUCTION), user.get_skill_value(SKILL_DEVICES))
 	repair_brute_damage(repair_value)
-	to_chat(user, SPAN_NOTICE("You mend the damage to [src]."))
+	USE_FEEDBACK_REPAIR_GENERAL
 
 /obj/item/mech_component/proc/repair_burn_generic(obj/item/stack/cable_coil/CC, mob/user)
 	if(!istype(CC))

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -140,12 +140,12 @@
 	var/amount = (SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION)
 	if(!tool.tool_start_check(user, amount))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 1 SECONDS, amount, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !brute_damage)
 		return
 	var/repair_value = 10 * max(user.get_skill_value(SKILL_CONSTRUCTION), user.get_skill_value(SKILL_DEVICES))
 	repair_brute_damage(repair_value)
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 
 /obj/item/mech_component/proc/repair_burn_generic(obj/item/stack/cable_coil/CC, mob/user)
 	if(!istype(CC))

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -140,12 +140,12 @@
 	var/amount = (SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION)
 	if(!tool.tool_start_check(user, amount))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 1 SECONDS, amount, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !brute_damage)
 		return
 	var/repair_value = 10 * max(user.get_skill_value(SKILL_CONSTRUCTION), user.get_skill_value(SKILL_DEVICES))
 	repair_brute_damage(repair_value)
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 
 /obj/item/mech_component/proc/repair_burn_generic(obj/item/stack/cable_coil/CC, mob/user)
 	if(!istype(CC))

--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -140,7 +140,7 @@
 	var/amount = (SKILL_MAX + 1) - user.get_skill_value(SKILL_CONSTRUCTION)
 	if(!tool.tool_start_check(user, amount))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 1 SECONDS, amount, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !brute_damage)
 		return
 	var/repair_value = 10 * max(user.get_skill_value(SKILL_CONSTRUCTION), user.get_skill_value(SKILL_DEVICES))

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -232,10 +232,7 @@
 		return
 	is_reinforced = FRAME_REINFORCED_SECURE
 	update_icon()
-	user.visible_message(
-		SPAN_NOTICE("[user] unwelds [src]'s internal reinforcements with [tool]."),
-		SPAN_NOTICE("You unweld [src]'s internal reinforcements with [tool]."),
-	)
+	balloon_alert_to_viewers("укрепления отварены!")
 
 /obj/structure/heavy_vehicle_frame/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
@@ -256,10 +253,7 @@
 		return
 	is_reinforced = FRAME_REINFORCED_WELDED
 	update_icon()
-	user.visible_message(
-		SPAN_NOTICE("[user] welds [src]'s internal reinforcements with [tool]."),
-		SPAN_NOTICE("You weld [src]'s internal reinforcements with [tool]."),
-	)
+	balloon_alert_to_viewers("укрепления заварены!")
 
 /obj/structure/heavy_vehicle_frame/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Cable Coil - Install wiring

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -247,7 +247,7 @@
 			balloon_alert(user, "укрепление уже заварено!")
 			return
 		if(FRAME_REINFORCED)
-			balloon_alert(user, "необходимо прикрутить укрепления!")
+			balloon_alert(user, "нужно прикрутить укрепления!")
 			return
 	if(!tool.tool_start_check(user, 1))
 		return

--- a/code/modules/mechs/components/frame.dm
+++ b/code/modules/mechs/components/frame.dm
@@ -217,29 +217,48 @@
 		SPAN_NOTICE("You [input == "Adjust Wiring" ? "adjust" : "remove"] the wiring in [src] with [tool].")
 	)
 
-/obj/structure/heavy_vehicle_frame/welder_act(mob/living/user, obj/item/tool)
+/obj/structure/heavy_vehicle_frame/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!is_reinforced)
-		USE_FEEDBACK_FAILURE("[src] has no reinforcements to weld.")
+		balloon_alert(user, "нет укреплений для отваривания!")
 		return
-	if(is_reinforced == FRAME_REINFORCED)
-		USE_FEEDBACK_FAILURE("[src]'s reinforcements need to be secured before you can weld them.")
+	if(is_reinforced != FRAME_REINFORCED_WELDED)
+		balloon_alert(user, "укрепление уже отварено!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	var/current_state = is_reinforced
-	user.visible_message(
-		SPAN_NOTICE("[user] starts [is_reinforced == FRAME_REINFORCED_WELDED ? "un" : null]welding [src]'s internal reinforcements with [tool]."),
-		SPAN_NOTICE("You start [is_reinforced == FRAME_REINFORCED_WELDED ? "un" : null]welding [src]'s internal reinforcements with [tool]."),
-		SPAN_ITALIC("You hear welding.")
-	)
-	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !is_reinforced || is_reinforced == FRAME_REINFORCED || current_state != is_reinforced)
+	balloon_alert(user, "отваривание укреплений")
+	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !is_reinforced || is_reinforced != FRAME_REINFORCED_WELDED)
 		return
-	is_reinforced = is_reinforced == FRAME_REINFORCED_WELDED ? FRAME_REINFORCED_SECURE : FRAME_REINFORCED_WELDED
+	is_reinforced = FRAME_REINFORCED_SECURE
 	update_icon()
 	user.visible_message(
-		SPAN_NOTICE("[user] [is_reinforced == FRAME_REINFORCED_WELDED ? "un" : null]welds [src]'s internal reinforcements with [tool]."),
-		SPAN_NOTICE("You [is_reinforced == FRAME_REINFORCED_WELDED ? "un" : null]weld [src]'s internal reinforcements with [tool]."),
+		SPAN_NOTICE("[user] unwelds [src]'s internal reinforcements with [tool]."),
+		SPAN_NOTICE("You unweld [src]'s internal reinforcements with [tool]."),
+	)
+
+/obj/structure/heavy_vehicle_frame/welder_act(mob/living/user, obj/item/tool)
+	. = ITEM_INTERACT_SUCCESS
+	if(!is_reinforced)
+		balloon_alert(user, "нет укреплений для приваривания!")
+		return
+	switch(is_reinforced)
+		if(FRAME_REINFORCED_WELDED)
+			balloon_alert(user, "укрепление уже заварено!")
+			return
+		if(FRAME_REINFORCED)
+			balloon_alert(user, "необходимо прикрутить укрепления!")
+			return
+	if(!tool.tool_start_check(user, 1))
+		return
+	balloon_alert(user, "заваривание укреплений")
+	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_REPAIR_CONSTRUCT) || !is_reinforced || is_reinforced != FRAME_REINFORCED_SECURE)
+		return
+	is_reinforced = FRAME_REINFORCED_WELDED
+	update_icon()
+	user.visible_message(
+		SPAN_NOTICE("[user] welds [src]'s internal reinforcements with [tool]."),
+		SPAN_NOTICE("You weld [src]'s internal reinforcements with [tool]."),
 	)
 
 /obj/structure/heavy_vehicle_frame/use_tool(obj/item/tool, mob/user, list/click_params)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -409,7 +409,7 @@
 /mob/living/exosuit/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!getBruteLoss())
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	var/list/damaged_parts = list()
 	for(var/obj/item/mech_component/component in list(arms, legs, body, head))

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -408,18 +408,18 @@
 
 /mob/living/exosuit/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
-	if (!getBruteLoss())
-		USE_FEEDBACK_FAILURE("[src] has no physical damage to repair.")
+	if(!getBruteLoss())
+		balloon_alert(user, "нет повреждений!")
 		return
 	var/list/damaged_parts = list()
-	for (var/obj/item/mech_component/component in list(arms, legs, body, head))
-		if (component?.brute_damage)
+	for(var/obj/item/mech_component/component in list(arms, legs, body, head))
+		if(component?.brute_damage)
 			damaged_parts += component
 	var/obj/item/mech_component/input_fix = input(user, "Which component would you like to fix?", "[src] - Fix Component") as null|anything in damaged_parts
-	if (!input_fix || !user.use_sanity_check(src, tool))
+	if(!input_fix || !user.use_sanity_check(src, tool))
 		return
-	if (!input_fix.brute_damage)
-		USE_FEEDBACK_FAILURE("[src]'s [input_fix.name] no longer needs repair.")
+	if(!input_fix.brute_damage)
+		balloon_alert(user, "больше не нуждается в ремонте!")
 		return
 	input_fix.repair_brute_generic(tool, user)
 

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -409,7 +409,7 @@
 /mob/living/exosuit/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!getBruteLoss())
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	var/list/damaged_parts = list()
 	for(var/obj/item/mech_component/component in list(arms, legs, body, head))

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -68,7 +68,7 @@
 /obj/structure/mech_wreckage/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(prepared)
-		USE_FEEDBACK_FAILURE("[src] has already been weakened.")
+		balloon_alert(user, "уже ослаблено!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -68,15 +68,12 @@
 /obj/structure/mech_wreckage/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(prepared)
-		balloon_alert(user, "уже ослаблено!")
+		balloon_alert(user, "структура уже ослаблена!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	prepared = TRUE
-	user.visible_message(
-		SPAN_NOTICE("[user] partially cuts through [src] with [tool]."),
-		SPAN_NOTICE("You partially cut through [src] with [tool].")
-	)
+	balloon_alert_to_viewers("структура ослаблена!")
 
 /obj/structure/mech_wreckage/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Welding Tool, Plasma Cutter - Cut through wreckage

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -106,19 +106,16 @@
 /mob/living/bot/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health >= maxHealth)
-		USE_FEEDBACK_FAILURE("[src] doesn't need any repairs.")
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!open)
-		USE_FEEDBACK_FAILURE("[src]'s access panel must be open to repair it.")
+		balloon_alert(user, "необходимо открыть панель для ремонта!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 5, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	health = min(maxHealth, health + 10)
 	update_icon()
-	user.visible_message(
-		SPAN_NOTICE("[user] repairs some of [src]'s damage with [tool]."),
-		SPAN_NOTICE("You repair some of [src]'s damage with [tool].")
-	)
+	USE_FEEDBACK_REPAIR_GENERAL
 
 /mob/living/bot/use_tool(obj/item/tool, mob/user, list/click_params)
 	// ID Card - Toggle access panel lock

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -106,7 +106,7 @@
 /mob/living/bot/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health >= maxHealth)
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!open)
 		balloon_alert(user, "нужно открыть панель для ремонта!")
@@ -115,7 +115,7 @@
 		return
 	health = min(maxHealth, health + 10)
 	update_icon()
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 
 /mob/living/bot/use_tool(obj/item/tool, mob/user, list/click_params)
 	// ID Card - Toggle access panel lock

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -106,16 +106,16 @@
 /mob/living/bot/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health >= maxHealth)
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!open)
-		balloon_alert(user, "необходимо открыть панель для ремонта!")
+		balloon_alert(user, "нужно открыть панель для ремонта!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 5, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	health = min(maxHealth, health + 10)
 	update_icon()
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 
 /mob/living/bot/use_tool(obj/item/tool, mob/user, list/click_params)
 	// ID Card - Toggle access panel lock

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -619,25 +619,19 @@
 /mob/living/silicon/robot/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(user == src)
-		USE_FEEDBACK_FAILURE("You lack the reach to be able to repair yourself.")
+		balloon_alert(user, "вы не можете ремонтировать себя!")
 		return
 	if(!getBruteLoss())
-		USE_FEEDBACK_FAILURE("[src] has no physical damage to repair.")
+		balloon_alert(user, "нет физических повреждений!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts repairing some of the dents on [src] with [tool]."),
-		SPAN_NOTICE("You start repairing some of the dents on [src] with [tool]."),
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 1 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_PUBLIC_UNIQUE) || !getBruteLoss())
 		return
+	USE_FEEDBACK_REPAIR_GENERAL
 	adjustBruteLoss(-30)
 	updatehealth()
-	user.visible_message(
-		SPAN_NOTICE("[user] repairs some of the dents on [src] with [tool]."),
-		SPAN_NOTICE("You repair some of the dents on [src] with [tool]."),
-	)
 
 /mob/living/silicon/robot/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Components - Attempt to install

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -626,10 +626,10 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 1 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_PUBLIC_UNIQUE) || !getBruteLoss())
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	adjustBruteLoss(-30)
 	updatehealth()
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -626,7 +626,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 1 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_PUBLIC_UNIQUE) || !getBruteLoss())
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -626,10 +626,10 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 1 SECONDS, 1, 50, SKILL_DEVICES, do_flags = DO_PUBLIC_UNIQUE) || !getBruteLoss())
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	adjustBruteLoss(-30)
 	updatehealth()
 

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -149,16 +149,16 @@
 /obj/item/modular_computer/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!get_damage_value())
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	var/damage = get_damage_value()
 	var/amount = round(damage/75)
 	if(!tool.tool_start_check(amount, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, damage / (1 SECONDS), amount, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	revive_health()
 
 /obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -149,17 +149,17 @@
 /obj/item/modular_computer/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!get_damage_value())
-		to_chat(user, "[src] does not require repairs.")
+		balloon_alert(user, "нет повреждений!")
 		return
 	var/damage = get_damage_value()
 	var/amount = round(damage/75)
 	if(!tool.tool_start_check(amount, 1))
 		return
-	to_chat(user, "You begin repairing damage to [src]...")
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, damage / (1 SECONDS), amount, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
+	USE_FEEDBACK_REPAIR_GENERAL
 	revive_health()
-	to_chat(user, "You repair [src].")
 
 /obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/card/id)) // ID Card, try to insert it.

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -149,16 +149,16 @@
 /obj/item/modular_computer/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!get_damage_value())
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	var/damage = get_damage_value()
 	var/amount = round(damage/75)
 	if(!tool.tool_start_check(amount, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, damage / (1 SECONDS), amount, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	revive_health()
 
 /obj/item/modular_computer/attackby(obj/item/W as obj, mob/user as mob)

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -155,7 +155,7 @@
 	var/amount = round(damage/75)
 	if(!tool.tool_start_check(amount, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, damage / (1 SECONDS), amount, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -211,14 +211,14 @@
 	. = ITEM_INTERACT_SUCCESS
 	var/damage = get_damage_value()
 	if(!damage)
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, (max(0.5, damage / 50)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	revive_health()
 
 /obj/machinery/shipsensors/proc/remove_tracker(obj/item/ship_tracker/tracker)

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -211,14 +211,14 @@
 	. = ITEM_INTERACT_SUCCESS
 	var/damage = get_damage_value()
 	if(!damage)
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, (max(0.5, damage / 50)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	revive_health()
 
 /obj/machinery/shipsensors/proc/remove_tracker(obj/item/ship_tracker/tracker)

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -211,14 +211,14 @@
 	. = ITEM_INTERACT_SUCCESS
 	var/damage = get_damage_value()
 	if(!damage)
-		to_chat(user, SPAN_WARNING("[src] doesn't need any repairs."))
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, (max(0.5, damage / 50)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+	USE_FEEDBACK_REPAIR_GENERAL
 	revive_health()
 
 /obj/machinery/shipsensors/proc/remove_tracker(obj/item/ship_tracker/tracker)

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -215,7 +215,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, (max(0.5, damage / 50)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -42,10 +42,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts burning away [src] with [tool]."),
-		SPAN_NOTICE("You start burning away [src] with [tool].")
-	)
+	balloon_alert(user, "очистка надписей")
 	if(!tool.use_as_tool(src, user, 1 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message(

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -528,17 +528,17 @@
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!opened)
-		balloon_alert(user, "необходимо открыть панель!")
+		balloon_alert(user, "нужно открыть панель!")
 		return
 	if(has_electronics)
-		balloon_alert(user, "необходимо убрать плату!")
+		balloon_alert(user, "нужно убрать плату!")
 		return
 	if(terminal())
-		balloon_alert(user, "необходимо убрать проводку!")
+		balloon_alert(user, "нужно убрать проводку!")
 		return
 	if(!tool.tool_start_check(user, 3))
 		return
-	balloon_alert(user, "разбор")
+	USE_FEEDBACK_DECONSTRUCT_START
 	if(!tool.use_as_tool(src, user, 5 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !opened || has_electronics || terminal())
 		return
 	if(emagged || MACHINE_IS_BROKEN(src) || opened == 2)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -538,7 +538,7 @@
 		return
 	if(!tool.tool_start_check(user, 3))
 		return
-	USE_FEEDBACK_DECONSTRUCT_START
+	USE_FEEDBACK_DECONSTRUCT_START(user)
 	if(!tool.use_as_tool(src, user, 5 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !opened || has_electronics || terminal())
 		return
 	if(emagged || MACHINE_IS_BROKEN(src) || opened == 2)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -528,23 +528,19 @@
 /obj/machinery/power/apc/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!opened)
-		to_chat(user, SPAN_WARNING("You must first open the cover."))
+		balloon_alert(user, "необходимо открыть панель!")
 		return
 	if(has_electronics)
-		to_chat(user, SPAN_WARNING("You must first remove the power control board inside."))
+		balloon_alert(user, "необходимо убрать плату!")
 		return
 	if(terminal())
-		to_chat(user, SPAN_WARNING("The wire connection is in the way."))
+		balloon_alert(user, "необходимо убрать проводку!")
 		return
-
 	if(!tool.tool_start_check(user, 3))
 		return
-	user.visible_message(SPAN_WARNING("[user] begins to weld [src]."), \
-						"You start welding the APC frame...", \
-						"You hear welding.")
+	balloon_alert(user, "начало разбора")
 	if(!tool.use_as_tool(src, user, 5 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !opened || has_electronics || terminal())
 		return
-
 	if(emagged || MACHINE_IS_BROKEN(src) || opened == 2)
 		new /obj/item/stack/material/steel(loc)
 		user.visible_message(\

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -538,7 +538,7 @@
 		return
 	if(!tool.tool_start_check(user, 3))
 		return
-	balloon_alert(user, "начало разбора")
+	balloon_alert(user, "разбор")
 	if(!tool.use_as_tool(src, user, 5 SECONDS, 3, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !opened || has_electronics || terminal())
 		return
 	if(emagged || MACHINE_IS_BROKEN(src) || opened == 2)

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -62,7 +62,7 @@
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 75, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	anchored = !anchored
-	user.visible_message("[user] [anchored ? null : "un"]secures [src] to the floor.")
+	balloon_alert_to_viewers("[anchored ? "приварено к полу!" : "отварено от пола!"]")
 
 /obj/machinery/fusion_fuel_injector/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/fuel_assembly))

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -57,7 +57,7 @@
 /obj/machinery/fusion_fuel_injector/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(injecting)
-		balloon_alert(user, "необходимо отключить!")
+		balloon_alert(user, "нужно отключить!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 75, do_flags = DO_REPAIR_CONSTRUCT))
 		return

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -57,7 +57,7 @@
 /obj/machinery/fusion_fuel_injector/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(injecting)
-		to_chat(user, SPAN_WARNING("Shut [src] off first!"))
+		balloon_alert(user, "необходимо отключить!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 75, do_flags = DO_REPAIR_CONSTRUCT))
 		return

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -205,19 +205,15 @@
 /obj/machinery/power/emitter/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(active)
-		to_chat(user, SPAN_WARNING("Turn [src] off first."))
+		balloon_alert(user, "необходимо отключить!")
 		return TRUE
 	switch(state)
 		if(EMITTER_LOOSE)
-			to_chat(user, SPAN_WARNING("[src] needs to be wrenched to the floor."))
+			balloon_alert(user, "необходимо прикрутить к полу!")
 		if(EMITTER_WRENCHED)
 			if(!tool.tool_start_check(user, 1))
 				return
-			user.visible_message(
-				SPAN_NOTICE("[user] starts to weld [src] to the floor."),
-				SPAN_NOTICE("You start to weld [src] to the floor."),
-				SPAN_ITALIC("You hear welding.")
-			)
+			balloon_alert(user, "приваривание к полу")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = EMITTER_WELDED
@@ -230,11 +226,7 @@
 		if(EMITTER_WELDED)
 			if(!tool.tool_start_check(user, 1))
 				return
-			user.visible_message(
-				SPAN_NOTICE("[user] starts to cut [src] free from the floor."),
-				SPAN_NOTICE("You start to cut [src] free from the floor."),
-				SPAN_ITALIC("You hear welding.")
-			)
+			balloon_alert(user, "отваривание от пола")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = EMITTER_WRENCHED

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -217,11 +217,7 @@
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = EMITTER_WELDED
-			user.visible_message(
-				SPAN_NOTICE("[user] welds [src] to the floor."),
-				SPAN_NOTICE("You weld the base of [src] to the floor, securing it in place."),
-				SPAN_ITALIC("You hear welding.")
-			)
+			balloon_alert_to_viewers("приварено к полу!")
 			connect_to_network()
 		if(EMITTER_WELDED)
 			if(!tool.tool_start_check(user, 1))
@@ -230,11 +226,7 @@
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = EMITTER_WRENCHED
-			user.visible_message(
-				SPAN_NOTICE("[user] cuts [src] free from the floor."),
-				SPAN_NOTICE("You cut [src] free from the floor."),
-				SPAN_ITALIC("You hear welding.")
-			)
+			balloon_alert_to_viewers("отварено от пола!")
 			disconnect_from_network()
 
 /obj/machinery/power/emitter/use_tool(obj/item/W, mob/living/user, list/click_params)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -205,11 +205,11 @@
 /obj/machinery/power/emitter/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(active)
-		balloon_alert(user, "необходимо отключить!")
+		balloon_alert(user, "нужно отключить!")
 		return TRUE
 	switch(state)
 		if(EMITTER_LOOSE)
-			balloon_alert(user, "необходимо прикрутить к полу!")
+			USE_FEEDBACK_NEED_ANCHOR
 		if(EMITTER_WRENCHED)
 			if(!tool.tool_start_check(user, 1))
 				return
@@ -226,7 +226,7 @@
 		if(EMITTER_WELDED)
 			if(!tool.tool_start_check(user, 1))
 				return
-			balloon_alert(user, "отваривание от пола")
+			USE_FEEDBACK_UNWELD_FROM_FLOOR
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = EMITTER_WRENCHED

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -209,7 +209,7 @@
 		return TRUE
 	switch(state)
 		if(EMITTER_LOOSE)
-			USE_FEEDBACK_NEED_ANCHOR
+			USE_FEEDBACK_NEED_ANCHOR(user)
 		if(EMITTER_WRENCHED)
 			if(!tool.tool_start_check(user, 1))
 				return
@@ -222,7 +222,7 @@
 		if(EMITTER_WELDED)
 			if(!tool.tool_start_check(user, 1))
 				return
-			USE_FEEDBACK_UNWELD_FROM_FLOOR
+			USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = EMITTER_WRENCHED

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -120,7 +120,7 @@ field_generator power level display
 		return
 	switch(state)
 		if(0)
-			USE_FEEDBACK_NEED_ANCHOR
+			USE_FEEDBACK_NEED_ANCHOR(user)
 			return
 		if(1)
 			. = ITEM_INTERACT_SUCCESS
@@ -135,7 +135,7 @@ field_generator power level display
 			. = ITEM_INTERACT_SUCCESS
 			if(!tool.tool_start_check(user, 1))
 				return
-			USE_FEEDBACK_UNWELD_FROM_FLOOR
+			USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = 1

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -116,11 +116,11 @@ field_generator power level display
 /obj/machinery/field_generator/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(active)
-		balloon_alert(user, "необходимо отключить!")
+		balloon_alert(user, "нужно отключить!")
 		return
 	switch(state)
 		if(0)
-			balloon_alert(user, "необходимо прикрутить к полу!")
+			USE_FEEDBACK_NEED_ANCHOR
 			return
 		if(1)
 			. = ITEM_INTERACT_SUCCESS
@@ -139,7 +139,7 @@ field_generator power level display
 			. = ITEM_INTERACT_SUCCESS
 			if(!tool.tool_start_check(user, 1))
 				return
-			balloon_alert(user, "отваривание от пола")
+			USE_FEEDBACK_UNWELD_FROM_FLOOR
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = 1

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -114,36 +114,40 @@ field_generator power level display
 		return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/field_generator/welder_act(mob/living/user, obj/item/tool)
+	. = ITEM_INTERACT_SUCCESS
 	if(active)
-		to_chat(user, "[src] needs to be off.")
+		balloon_alert(user, "необходимо отключить!")
 		return
 	switch(state)
 		if(0)
-			. = ITEM_INTERACT_SUCCESS
-			to_chat(user, SPAN_WARNING("[src] needs to be wrenched to the floor."))
+			balloon_alert(user, "необходимо прикрутить к полу!")
 			return
 		if(1)
 			. = ITEM_INTERACT_SUCCESS
 			if(!tool.tool_start_check(user, 1))
 				return
-			user.visible_message("[user] starts to weld the [src] to the floor.", \
-				"You start to weld [src] to the floor.", \
-				"You hear welding")
+			balloon_alert(user, "приваривание к полу")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = 2
-			to_chat(user, "You weld [src] to the floor.")
+			user.visible_message(
+				SPAN_NOTICE("[user] welds [src] to the floor."),
+				SPAN_NOTICE("You weld the base of [src] to the floor, securing it in place."),
+				SPAN_ITALIC("You hear welding.")
+			)
 		if(2)
 			. = ITEM_INTERACT_SUCCESS
 			if(!tool.tool_start_check(user, 1))
 				return
-			user.visible_message("[user] starts to cut the [src] free from the floor.", \
-				"You start to cut [src] free from the floor.", \
-				"You hear welding")
+			balloon_alert(user, "отваривание от пола")
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = 1
-			to_chat(user, "You cut [src] free from the floor.")
+			user.visible_message(
+				SPAN_NOTICE("[user] cuts [src] free from the floor."),
+				SPAN_NOTICE("You cut [src] free from the floor."),
+				SPAN_ITALIC("You hear welding.")
+			)
 
 /obj/machinery/field_generator/emp_act()
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -130,11 +130,7 @@ field_generator power level display
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = 2
-			user.visible_message(
-				SPAN_NOTICE("[user] welds [src] to the floor."),
-				SPAN_NOTICE("You weld the base of [src] to the floor, securing it in place."),
-				SPAN_ITALIC("You hear welding.")
-			)
+			balloon_alert_to_viewers("приварено к полу!")
 		if(2)
 			. = ITEM_INTERACT_SUCCESS
 			if(!tool.tool_start_check(user, 1))
@@ -143,11 +139,7 @@ field_generator power level display
 			if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 				return
 			state = 1
-			user.visible_message(
-				SPAN_NOTICE("[user] cuts [src] free from the floor."),
-				SPAN_NOTICE("You cut [src] free from the floor."),
-				SPAN_ITALIC("You hear welding.")
-			)
+			balloon_alert_to_viewers("отварено от пола!")
 
 /obj/machinery/field_generator/emp_act()
 	SHOULD_CALL_PARENT(FALSE)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -247,14 +247,14 @@
 		balloon_alert(user, "нужно открыть панель!")
 		return
 	if(!damage)
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 5))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, damage, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !damage)
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	damage = 0
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -251,7 +251,7 @@
 		return
 	if(!tool.tool_start_check(user, 5))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, damage, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !damage)
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -243,17 +243,18 @@
 
 /obj/machinery/power/smes/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
-	if (!panel_open)
-		to_chat(user, SPAN_WARNING("You need to open the access hatch on [src] first!"))
+	if(!panel_open)
+		balloon_alert(user, "необходимо открыть панель!")
 		return
 	if(!damage)
-		to_chat(user, "[src] is already fully repaired.")
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!tool.tool_start_check(user, 5))
 		return
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, damage, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !damage)
 		return
-	to_chat(user, "You repair all structural damage to [src]")
+	USE_FEEDBACK_REPAIR_GENERAL
 	damage = 0
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -244,17 +244,17 @@
 /obj/machinery/power/smes/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!panel_open)
-		balloon_alert(user, "необходимо открыть панель!")
+		balloon_alert(user, "нужно открыть панель!")
 		return
 	if(!damage)
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 5))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, damage, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || !damage)
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	damage = 0
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -159,7 +159,7 @@
 	var/obj/structure/disposalpipe/connected_pipe = locate() in get_turf(src)
 	// Welding Tool - Weld into place
 	if(!anchored)
-		balloon_alert(user, "необходимо прикрутить к полу!")
+		USE_FEEDBACK_NEED_ANCHOR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -159,7 +159,7 @@
 	var/obj/structure/disposalpipe/connected_pipe = locate() in get_turf(src)
 	// Welding Tool - Weld into place
 	if(!anchored)
-		USE_FEEDBACK_NEED_ANCHOR
+		USE_FEEDBACK_NEED_ANCHOR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -159,15 +159,11 @@
 	var/obj/structure/disposalpipe/connected_pipe = locate() in get_turf(src)
 	// Welding Tool - Weld into place
 	if(!anchored)
-		USE_FEEDBACK_FAILURE("[src] needs to be anchored to the floor before you can weld it.")
+		balloon_alert(user, "необходимо прикрутить к полу!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts welding [src] down with [tool]."),
-		SPAN_NOTICE("You start welding [src] down with [tool]."),
-		SPAN_ITALIC("You hear welding.")
-	)
+	balloon_alert(user, "приваривание к полу")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message(

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -166,10 +166,6 @@
 	balloon_alert(user, "приваривание к полу")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] welds [src] down with [tool]."),
-		SPAN_NOTICE("You weld [src] down with [tool].")
-	)
 	build(connected_pipe)
 	qdel(src)
 
@@ -216,6 +212,7 @@
 	P.sort_type = sort_type
 	P.set_dir(dir)
 	P.on_build()
+	P.balloon_alert_to_viewers("приварено к полу!")
 
 // Subtypes
 
@@ -232,6 +229,7 @@
 	transfer_fingerprints_to(P)
 	P.set_dir(dir)
 	P.mode = 0 // start with pump off
+	P.balloon_alert_to_viewers("приварено к полу!")
 
 /obj/structure/disposalconstruct/machine/on_update_icon()
 	if(anchored)
@@ -245,3 +243,4 @@
 	P.set_dir(dir)
 	var/obj/structure/disposalpipe/trunk/Trunk = CP
 	Trunk.linked = P
+	P.balloon_alert_to_viewers("приварено к полу!")

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -117,10 +117,10 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, "You sliced the floorweld off the disposal unit.")
 	var/obj/structure/disposalconstruct/machine/C = new (loc, src)
 	transfer_fingerprints_to(C)
 	C.update()
+	C.balloon_alert_to_viewers("отварено от пола!")
 	qdel(src)
 
 /obj/machinery/disposal/use_tool(obj/item/I, mob/living/user, list/click_params)
@@ -621,15 +621,12 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] slices [src]'s floorweld with [tool]."),
-		SPAN_NOTICE("You start slices [src]'s floorweld with [tool].")
-	)
 	var/obj/structure/disposalconstruct/machine/outlet/outlet = new(loc, src)
 	transfer_fingerprints_to(outlet)
 	outlet.anchored = TRUE
 	outlet.set_density(TRUE)
 	outlet.update()
+	outlet.balloon_alert_to_viewers("отварено от пола!")
 	qdel(src)
 
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -110,11 +110,11 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 		return
 	. = ITEM_INTERACT_SUCCESS
 	if(length(contents) > LAZYLEN(component_parts))
-		balloon_alert(user, "необходимо вытащить предметы!")
+		balloon_alert(user, "нужно вытащить предметы!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "отваривание от пола")
+	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	to_chat(user, "You sliced the floorweld off the disposal unit.")
@@ -614,15 +614,15 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	. = ITEM_INTERACT_SUCCESS
 	// Welding Tool - Detach from floor
 	if(!mode)
-		balloon_alert(user, "необходимо отключить!")
+		balloon_alert(user, "нужно отключить!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "отваривание от пола")
+	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message(
-		SPAN_NOTICE("[user] slices [src]'s floorweld with  [tool]."),
+		SPAN_NOTICE("[user] slices [src]'s floorweld with [tool]."),
 		SPAN_NOTICE("You start slices [src]'s floorweld with [tool].")
 	)
 	var/obj/structure/disposalconstruct/machine/outlet/outlet = new(loc, src)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -110,11 +110,11 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 		return
 	. = ITEM_INTERACT_SUCCESS
 	if(length(contents) > LAZYLEN(component_parts))
-		to_chat(user, "Eject the items first!")
+		balloon_alert(user, "необходимо вытащить предметы!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	to_chat(user, "You start slicing the floorweld off the disposal unit.")
+	balloon_alert(user, "отваривание от пола")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	to_chat(user, "You sliced the floorweld off the disposal unit.")
@@ -614,15 +614,11 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	. = ITEM_INTERACT_SUCCESS
 	// Welding Tool - Detach from floor
 	if(!mode)
-		USE_FEEDBACK_FAILURE("[src]'s power connection needs to be disconnected before you can remove [src] from the floor.")
+		balloon_alert(user, "необходимо отключить!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts slicing [src]'s floorweld with  [tool]."),
-		SPAN_NOTICE("You start slicing [src]'s floorweld with [tool]."),
-		SPAN_ITALIC("You hear the sound of welding.")
-	)
+	balloon_alert(user, "отваривание от пола")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message(

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -114,7 +114,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_UNWELD_FROM_FLOOR
+	USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/structure/disposalconstruct/machine/C = new (loc, src)
@@ -618,7 +618,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_UNWELD_FROM_FLOOR
+	USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/structure/disposalconstruct/machine/outlet/outlet = new(loc, src)

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -230,7 +230,7 @@
 	// Welding Tool - Cut pipe
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "отваривание")
+	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded()

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -233,20 +233,12 @@
 	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	welded()
-	user.visible_message(
-		SPAN_NOTICE("[user] slices [src] with [tool]."),
-		SPAN_NOTICE("You slice [src] with [tool].")
-	)
-
-	// called when pipe is cut with welder
-/obj/structure/disposalpipe/proc/welded()
 	var/obj/structure/disposalconstruct/C = new (src.loc, src)
-	src.transfer_fingerprints_to(C)
+	transfer_fingerprints_to(C)
 	C.set_density(0)
 	C.anchored = TRUE
 	C.update()
-
+	C.balloon_alert_to_viewers("отверено от пола!")
 	qdel(src)
 
 // pipe is deleted
@@ -834,8 +826,13 @@
 	update()
 	return
 
-	// called when welded
-	// for broken pipe, remove and turn into scrap
-
-/obj/structure/disposalpipe/broken/welded()
+// for broken pipe, remove and turn into scrap
+/obj/structure/disposalpipe/broken/welder_act(mob/living/user, obj/item/tool)
+	. = ITEM_INTERACT_SUCCESS
+	// Welding Tool - Cut pipe
+	if(!tool.tool_start_check(user, 1))
+		return
+	USE_FEEDBACK_UNWELD_FROM_FLOOR
+	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
+		return
 	qdel(src)

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -230,7 +230,7 @@
 	// Welding Tool - Cut pipe
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_UNWELD_FROM_FLOOR
+	USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/structure/disposalconstruct/C = new (src.loc, src)
@@ -832,7 +832,7 @@
 	// Welding Tool - Cut pipe
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_UNWELD_FROM_FLOOR
+	USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	qdel(src)

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -230,10 +230,7 @@
 	// Welding Tool - Cut pipe
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts slicing [src] with [tool]."),
-		SPAN_NOTICE("You start slicing [src] with [tool].")
-	)
+	balloon_alert(user, "отваривание")
 	if(!tool.use_as_tool(src, user, 3 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	welded()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -614,7 +614,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "отваривание от пола")
+	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	to_chat(user, "You sliced the floorweld off the delivery chute.")

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -617,9 +617,9 @@
 	USE_FEEDBACK_UNWELD_FROM_FLOOR
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, "You sliced the floorweld off the delivery chute.")
 	var/obj/structure/disposalconstruct/C = new (loc, src)
 	C.update()
+	C.balloon_alert_to_viewers("отварено от пола!")
 	qdel(src)
 
 /obj/machinery/disposal/deliveryChute/Destroy()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -614,7 +614,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_UNWELD_FROM_FLOOR
+	USE_FEEDBACK_UNWELD_FROM_FLOOR(user)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	var/obj/structure/disposalconstruct/C = new (loc, src)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -614,7 +614,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	to_chat(user, "You start slicing the floorweld off the delivery chute.")
+	balloon_alert(user, "отваривание от пола")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	to_chat(user, "You sliced the floorweld off the delivery chute.")

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -149,15 +149,15 @@
 /obj/structure/table/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	restore_health(get_max_health() / 5) // 20% repair per application
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 
 /obj/structure/table/use_weapon(obj/item/weapon, mob/user, list/click_params)
 	// Carpet - Add carpeting

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -153,7 +153,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	restore_health(get_max_health() / 5) // 20% repair per application

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -149,15 +149,15 @@
 /obj/structure/table/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	restore_health(get_max_health() / 5) // 20% repair per application
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 
 /obj/structure/table/use_weapon(obj/item/weapon, mob/user, list/click_params)
 	// Carpet - Add carpeting

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -149,21 +149,15 @@
 /obj/structure/table/welder_act_secondary(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(!health_damaged())
-		USE_FEEDBACK_FAILURE("[src] isn't damaged.")
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] starts repairing [src] with [tool]."),
-		SPAN_NOTICE("You start repairing [src] with [tool].")
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	restore_health(get_max_health() / 5) // 20% repair per application
-	user.visible_message(
-		SPAN_NOTICE("[user] repairs some of [src]'s damage with [tool]."),
-		SPAN_NOTICE("You repair some of [src]'s damage with [tool].")
-	)
+	USE_FEEDBACK_REPAIR_GENERAL
 
 /obj/structure/table/use_weapon(obj/item/weapon, mob/user, list/click_params)
 	// Carpet - Add carpeting

--- a/maps/sierra/structures/other.dm
+++ b/maps/sierra/structures/other.dm
@@ -29,7 +29,7 @@
 	ClearOverlays()
 	bulletholes.Cut()
 	hp = initial(hp)
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 
 /obj/item/target/syndicate
 	icon_state = "target_s"

--- a/maps/sierra/structures/other.dm
+++ b/maps/sierra/structures/other.dm
@@ -29,11 +29,7 @@
 	ClearOverlays()
 	bulletholes.Cut()
 	hp = initial(hp)
-	user.visible_message(
-		SPAN_NOTICE("[user] slices off uneven chunks of aluminium and scorch marks from [src]."),
-		SPAN_NOTICE("You slice off uneven chunks of aluminium and scorch marks from [src]."),
-		SPAN_NOTICE("You hear welding."),
-	)
+	USE_FEEDBACK_REPAIR_FINISH
 
 /obj/item/target/syndicate
 	icon_state = "target_s"

--- a/mods/atmos_ret_field/code/atmospheric_retention_field.dm
+++ b/mods/atmos_ret_field/code/atmospheric_retention_field.dm
@@ -97,10 +97,10 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 5))
 		return
-	user.visible_message("[user] starts to disassemble [src].", "You start to disassemble [src].")
+	balloon_alert(user, "начало разбора")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, SPAN_NOTICE("You fully disassemble [src]. There were no salvageable parts."))
+	user.visible_message("[user] disassembles [src].", "You disassemble [src].")
 	qdel(src)
 
 /obj/machinery/atmospheric_field_generator/perma/Initialize()

--- a/mods/atmos_ret_field/code/atmospheric_retention_field.dm
+++ b/mods/atmos_ret_field/code/atmospheric_retention_field.dm
@@ -97,7 +97,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 5))
 		return
-	balloon_alert(user, "разбор")
+	USE_FEEDBACK_DECONSTRUCT_START
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message("[user] disassembles [src].", "You disassemble [src].")

--- a/mods/atmos_ret_field/code/atmospheric_retention_field.dm
+++ b/mods/atmos_ret_field/code/atmospheric_retention_field.dm
@@ -97,7 +97,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 5))
 		return
-	balloon_alert(user, "начало разбора")
+	balloon_alert(user, "разбор")
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message("[user] disassembles [src].", "You disassemble [src].")

--- a/mods/atmos_ret_field/code/atmospheric_retention_field.dm
+++ b/mods/atmos_ret_field/code/atmospheric_retention_field.dm
@@ -97,7 +97,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 5))
 		return
-	USE_FEEDBACK_DECONSTRUCT_START
+	USE_FEEDBACK_DECONSTRUCT_START(user)
 	if(!tool.use_as_tool(src, user, 2 SECONDS, 5, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	user.visible_message("[user] disassembles [src].", "You disassemble [src].")

--- a/mods/machinery/code/gravity_generator/base.dm
+++ b/mods/machinery/code/gravity_generator/base.dm
@@ -222,17 +222,11 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	user.visible_message(
-		SPAN_NOTICE("[user] begins to weld the damaged parts."),
-		SPAN_NOTICE("You begin to weld the damaged parts.")
-	)
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || broken_state != GRAV_NEEDS_WELDING)
 		return
 	health += 250
-	user.visible_message(
-		SPAN_NOTICE("[user] fixed the damaged parts."),
-		SPAN_NOTICE("You fixed the damaged parts.")
-	)
+	USE_FEEDBACK_REPAIR_GENERAL
 	set_broken_state(GRAV_NEEDS_WRENCH)
 	update_icon()
 

--- a/mods/machinery/code/gravity_generator/base.dm
+++ b/mods/machinery/code/gravity_generator/base.dm
@@ -222,7 +222,7 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || broken_state != GRAV_NEEDS_WELDING)
 		return
 	health += 250

--- a/mods/machinery/code/gravity_generator/base.dm
+++ b/mods/machinery/code/gravity_generator/base.dm
@@ -222,11 +222,11 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || broken_state != GRAV_NEEDS_WELDING)
 		return
 	health += 250
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	set_broken_state(GRAV_NEEDS_WRENCH)
 	update_icon()
 

--- a/mods/machinery/code/gravity_generator/base.dm
+++ b/mods/machinery/code/gravity_generator/base.dm
@@ -222,11 +222,11 @@
 	. = ITEM_INTERACT_SUCCESS
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, 15 SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT) || broken_state != GRAV_NEEDS_WELDING)
 		return
 	health += 250
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	set_broken_state(GRAV_NEEDS_WRENCH)
 	update_icon()
 

--- a/packs/infinity/structures/barrier.dm
+++ b/packs/infinity/structures/barrier.dm
@@ -140,7 +140,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	USE_FEEDBACK_REPAIR_GENERAL
@@ -252,7 +252,7 @@
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "начало ремонта")
+	balloon_alert(user, "ремонт")
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	USE_FEEDBACK_REPAIR_GENERAL

--- a/packs/infinity/structures/barrier.dm
+++ b/packs/infinity/structures/barrier.dm
@@ -136,14 +136,14 @@
 /obj/structure/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health == maxhealth)
-		to_chat(user, SPAN_NOTICE("[src] is fully repaired."))
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	visible_message(SPAN_WARNING("[user] is repairing [src]..."))
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+	USE_FEEDBACK_REPAIR_GENERAL
 	health = maxhealth
 
 /obj/structure/barrier/bullet_act(obj/item/projectile/P)
@@ -246,14 +246,14 @@
 		qdel(src)
 
 /obj/item/barrier/welder_act(mob/living/user, obj/item/tool)
-	if(health == initial(health))
-		to_chat(user, SPAN_NOTICE("[src] is fully repaired."))
-		return
 	. = ITEM_INTERACT_SUCCESS
+	if(health == initial(health))
+		balloon_alert(user, "нет повреждений!")
+		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	visible_message(SPAN_WARNING("[user] is repairing [src]..."))
+	balloon_alert(user, "начало ремонта")
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+	USE_FEEDBACK_REPAIR_GENERAL
 	health = initial(health)

--- a/packs/infinity/structures/barrier.dm
+++ b/packs/infinity/structures/barrier.dm
@@ -136,14 +136,14 @@
 /obj/structure/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health == maxhealth)
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	health = maxhealth
 
 /obj/structure/barrier/bullet_act(obj/item/projectile/P)
@@ -248,12 +248,12 @@
 /obj/item/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health == initial(health))
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	USE_FEEDBACK_REPAIR_START
+	USE_FEEDBACK_REPAIR_START(user)
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 	health = initial(health)

--- a/packs/infinity/structures/barrier.dm
+++ b/packs/infinity/structures/barrier.dm
@@ -136,14 +136,14 @@
 /obj/structure/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health == maxhealth)
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	health = maxhealth
 
 /obj/structure/barrier/bullet_act(obj/item/projectile/P)
@@ -248,12 +248,12 @@
 /obj/item/barrier/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health == initial(health))
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!tool.tool_start_check(user, 1))
 		return
-	balloon_alert(user, "ремонт")
+	USE_FEEDBACK_REPAIR_START
 	if(!tool.use_as_tool(src, user, (max(5, health / 5)) SECONDS, 1, 50, SKILL_CONSTRUCTION, do_flags = DO_REPAIR_CONSTRUCT))
 		return
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 	health = initial(health)

--- a/packs/sierra-tweaks/objects/vehicles/vehicle.dm
+++ b/packs/sierra-tweaks/objects/vehicles/vehicle.dm
@@ -100,15 +100,15 @@
 /obj/vehicle/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health >= maxhealth)
-		balloon_alert(user, "нет повреждений!")
+		USE_FEEDBACK_NOTHING_TO_REPAIR
 		return
 	if(!open)
-		balloon_alert(user, "необходимо открыть панель!")
+		balloon_alert(user, "нужно открыть панель!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	adjust_health(10)
-	USE_FEEDBACK_REPAIR_GENERAL
+	USE_FEEDBACK_REPAIR_FINISH
 
 /obj/vehicle/use_tool(obj/item/tool, mob/user, list/click_params)
 	if(istype(tool, /obj/item/hand_labeler))

--- a/packs/sierra-tweaks/objects/vehicles/vehicle.dm
+++ b/packs/sierra-tweaks/objects/vehicles/vehicle.dm
@@ -100,15 +100,15 @@
 /obj/vehicle/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health >= maxhealth)
-		to_chat(user, SPAN_NOTICE("[src] does not need a repair."))
+		balloon_alert(user, "нет повреждений!")
 		return
 	if(!open)
-		to_chat(user, SPAN_NOTICE("Unable to repair with the maintenance panel closed."))
+		balloon_alert(user, "необходимо открыть панель!")
 		return
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	adjust_health(10)
-	user.visible_message(SPAN_WARNING("[user] repairs [src]!"), SPAN_NOTICE("You repair [src]!"))
+	USE_FEEDBACK_REPAIR_GENERAL
 
 /obj/vehicle/use_tool(obj/item/tool, mob/user, list/click_params)
 	if(istype(tool, /obj/item/hand_labeler))

--- a/packs/sierra-tweaks/objects/vehicles/vehicle.dm
+++ b/packs/sierra-tweaks/objects/vehicles/vehicle.dm
@@ -100,7 +100,7 @@
 /obj/vehicle/welder_act(mob/living/user, obj/item/tool)
 	. = ITEM_INTERACT_SUCCESS
 	if(health >= maxhealth)
-		USE_FEEDBACK_NOTHING_TO_REPAIR
+		USE_FEEDBACK_NOTHING_TO_REPAIR(user)
 		return
 	if(!open)
 		balloon_alert(user, "нужно открыть панель!")
@@ -108,7 +108,7 @@
 	if(!tool.use_as_tool(src, user, amount = 1, volume = 50, do_flags = DO_REPAIR_CONSTRUCT))
 		return
 	adjust_health(10)
-	USE_FEEDBACK_REPAIR_FINISH
+	USE_FEEDBACK_REPAIR_FINISH(user)
 
 /obj/vehicle/use_tool(obj/item/tool, mob/user, list/click_params)
 	if(istype(tool, /obj/item/hand_labeler))


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Стандартизирует большинство действий со сварочным аппаратом:
- Сообщение о результате зрителям в конце действия баллун алертом
- Начало действия (если продолжительное) баллун алертом о том, что делает пользователь
- Ошибки действия баллун алертом
- Приваривание/отваривание укрепления на мехе на ЛКМ/ПКМ

Баллун алерты на русском

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Меньше смотреть в чат
Меньше спама в чат "начинает чинить, начинает резать"

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

Потыкал в ЛКП, в стену, в меха

## Changelog

:cl:
tweak: Стандартизация фидбека при использовании сварочного аппарата - баллун алерты при начале продолжительного действия и оповещение об окончании работы в чат
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
