### PR TITLE
fix: properly get other gases for atoms alarm

### DIFF
--- a/code/game/machinery/alarm/alarm.dm
+++ b/code/game/machinery/alarm/alarm.dm
@@ -141,7 +141,7 @@
 	..(loc)
 
 	if(dir)
-		src.set_dir(dir)
+		set_dir(dir)
 
 	if(istype(frame))
 		buildstage = 0
@@ -966,11 +966,11 @@
 	report_danger_level = 0
 	breach_pressure = -1
 
-/obj/machinery/alarm/server/New()
-	..()
+/obj/machinery/alarm/server/Initialize()
+	. = ..()
 	req_access = list(access_rd, access_atmospherics, access_engine_equip)
-	TLV["temperature"] =	list(T0C-26, T0C, T0C+30, T0C+40) // K
-	target_temperature = T0C+10
+	TLV["temperature"] = list(T0C-26, T0C, T0C+30, T0C+40)
+	target_temperature = T0C + 10
 
 /*
 AIR ALARM CIRCUIT


### PR DESCRIPTION
## Что этот PR делает

Чинит сенсоры аир алярм, уж слишком чувствительные они были

## Почему это хорошо для игры

Аир алярмы не пищат от 0.01 моля форона в больших зонах

## Тестирование

Компилировал, заспавнил газ. Алярмы реагируют адекватно

## Changelog

:cl:
fix: Air Alarm не реагирует на ничтожно малые обьемы опасных газов
/:cl:

