### PR TITLE
Signals for updated lying/buckled is sent now only when it's changed...

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -743,9 +743,10 @@
 	if(update_icon)	//forces a full overlay update
 		update_icon = FALSE
 		regenerate_icons()
+		SEND_SIGNAL(src, COMSIG_MOB_UPDATE_LYING_BUCKLED_VERBSTATUS)
 	else if( lying != lying_prev )
 		update_icons()
-	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_LYING_BUCKLED_VERBSTATUS)
+		SEND_SIGNAL(src, COMSIG_MOB_UPDATE_LYING_BUCKLED_VERBSTATUS)
 
 /mob/proc/reset_layer()
 	if(lying)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Теперь сигнал у UpdateLyingBuckledAndVerbStatus() отправляется только если что-то обновилось.
Когда-нибудь это надо будет уничтожить этот прок, но этот день не сегодня.

fixes https://github.com/ss220club/WyccerraBay220/issues/191

## Changelog

:cl:
fix: Пиксель-шифт больше не сбрасывается во время процессинга моба
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
