### PR TITLE
Use correct proc for checking FBP xeno-whitelist

### DIFF
--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -102,6 +102,8 @@ var/global/list/alien_whitelist = list()
 	return FALSE
 
 /proc/whitelist_lookup(item, ckey)
+	if(!config.usealienwhitelist)
+		return TRUE
 	return alien_whitelist?[ckey]?[lowertext(item)]
 
 #undef WHITELISTFILE

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -102,8 +102,6 @@ var/global/list/alien_whitelist = list()
 	return FALSE
 
 /proc/whitelist_lookup(item, ckey)
-	if(!config.usealienwhitelist)
-		return TRUE
 	return alien_whitelist?[ckey]?[lowertext(item)]
 
 #undef WHITELISTFILE

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -536,7 +536,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 				third_limb =  BP_GROIN
 				choice_options = list("Normal","Prosthesis")
 
-				if((!whitelist_lookup(SPECIES_FBP, user.ckey) && current_species.name != SPECIES_IPC) && !user.client.holder)
+				if((!is_any_alien_whitelisted(user, SPECIES_FBP) && current_species.name != SPECIES_IPC) && !user.client.holder)
 					choice_options -= "Prosthesis"
 
 		var/new_state = input(user, "What state do you wish the limb to be in?") as null|anything in choice_options

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -212,7 +212,7 @@
 			return 0
 
 		if(client.prefs.organ_data[BP_CHEST] == "cyborg")
-			if(!whitelist_lookup(SPECIES_FBP, client.ckey) && client.prefs.species != SPECIES_IPC)
+			if(!is_any_alien_whitelisted(src, SPECIES_FBP) && client.prefs.species != SPECIES_IPC)
 				to_chat(usr, "Нельзя зайти за ППТ без вайтлиста.")
 				return FALSE
 
@@ -472,7 +472,7 @@
 /mob/new_player/proc/create_character(turf/spawn_turf)
 	spawning = 1
 	if(client.prefs.organ_data[BP_CHEST] == "cyborg")
-		if(!whitelist_lookup(SPECIES_FBP, client.ckey) && client.prefs.species != SPECIES_IPC)
+		if(!is_any_alien_whitelisted(src, SPECIES_FBP) && client.prefs.species != SPECIES_IPC)
 			to_chat(src, "Нельзя зайти за ППТ без вайтлиста.")
 			spawning = 0
 			return null


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Использование стандартной проверки на вайтлист, вместо вспомогательного прока, для ППТ вайтлиста.

## Changelog

:cl:
fix: Теперь снова можно брать ППТ при выключенном ксено-вайтлисте
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
