### PR TITLE
Fix Ears loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/earwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/earwear.dm
@@ -43,12 +43,12 @@
 	whitelisted = list(SPECIES_SKRELL)
 
 /datum/gear/ears/skrell/bands
-	display_name = "headtail band selection (Skrell)"
+	display_name = "headtail band (Skrell)"
 	path = /obj/item/clothing/ears/skrell/band
 	flags = GEAR_HAS_SUBTYPE_SELECTION
 
 /datum/gear/ears/skrell/chains
-	display_name = "headtail chain selection (Skrell)"
+	display_name = "headtail chain (Skrell)"
 	path = /obj/item/clothing/ears/skrell/chain
 	flags = GEAR_HAS_SUBTYPE_SELECTION
 
@@ -57,11 +57,11 @@
 	flags = GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/ears/skrell/colored/chain
-	display_name = "colored headtail chain, colour select (Skrell)"
+	display_name = "headtail chain, colored (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/chain
 
 /datum/gear/ears/skrell/colored/band
-	display_name = "headtail bands, colour select (Skrell)"
+	display_name = "headtail band, colored (Skrell)"
 	path = /obj/item/clothing/ears/skrell/colored/band
 
 /datum/gear/ears/skrell/cloth
@@ -69,9 +69,9 @@
 	flags = GEAR_HAS_COLOR_SELECTION
 
 /datum/gear/ears/skrell/cloth/male
-	display_name = "male headtail cloth (Skrell)"
+	display_name = "headtail cloth, male (Skrell)"
 	path = /obj/item/clothing/ears/skrell/cloth_male
 
 /datum/gear/ears/skrell/cloth/female
-	display_name = "female headtail cloth (Skrell)"
+	display_name = "headtail cloth, female (Skrell)"
 	path = /obj/item/clothing/ears/skrell/cloth_female


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

- Абстрактный тип "уши"
- Теперь можно взять противоударные наушники

## Changelog

:cl:
fix: Теперь серьги в лодауте можно выбирать
fix: Теперь можно брать противоударные наушники
tweak: Переименованы скрелловские украшения на уши для группировки
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
