### PR TITLE
damage from pulling from to_chat to balloon

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -608,13 +608,13 @@ default behaviour is:
 	if(lying && prob(getBruteLoss() / 6))
 		location.add_blood(src)
 		if(prob(25))
-			src.adjustBruteLoss(1)
-			visible_message(SPAN_CLASS("danger", "\The [src]'s [src.isSynthetic() ? "state worsens": "wounds open more"] from being dragged!"))
+			adjustBruteLoss(1)
+			balloon_alert_to_viewers("[isSynthetic() ? "повреждения ухудшаются!" : "раны открываются!"]")
 			. = TRUE
-	if(src.pull_damage())
+	if(pull_damage())
 		if(prob(25))
-			src.adjustBruteLoss(2)
-			visible_message(SPAN_CLASS("danger", "\The [src]'s [src.isSynthetic() ? "state" : "wounds"] worsen terribly from being dragged!"))
+			adjustBruteLoss(2)
+			balloon_alert_to_viewers("[isSynthetic() ? "повреждения значительно ухудшаются!" : "раны сильно открываются!"]")
 			location.add_blood(src)
 			. = TRUE
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -609,12 +609,12 @@ default behaviour is:
 		location.add_blood(src)
 		if(prob(25))
 			adjustBruteLoss(1)
-			balloon_alert_to_viewers("[isSynthetic() ? "повреждения ухудшаются!" : "раны открываются!"]")
+			balloon_alert_to_viewers("[isSynthetic() ? "состояние ухудшается!" : "травмы усиливаются!"]")
 			. = TRUE
 	if(pull_damage())
 		if(prob(25))
 			adjustBruteLoss(2)
-			balloon_alert_to_viewers("[isSynthetic() ? "повреждения значительно ухудшаются!" : "раны сильно открываются!"]")
+			balloon_alert_to_viewers("[isSynthetic() ? "состояние значительно ухудшается!" : "травмы многократно усиливаются!"]")
 			location.add_blood(src)
 			. = TRUE
 


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Перемещает сообщения об уроне от пулла с ту-чата в баллун-алерты

## Почему это хорошо для игры

<!-- Опишите, почему, по вашему, следует добавить эти изменения в игру. -->

Меньше смотреть в чат

## Тестирование

<!-- Как вы тестировали свой PR, если делали это вовсе? -->

## Changelog

:cl:
tweak: Сообщение о получении урона от пулла перемещено с ту-чата в баллун-алерты
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
