### PR TITLE
fix ui when storage is removed from another storage

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -102,6 +102,9 @@
 			return
 
 		src.add_fingerprint(usr)
+		if(istype(src.loc, /obj/item/storage))
+			var/obj/item/storage/parent_storage = src.loc
+			parent_storage.remove_from_storage(src)
 		if(usr.unEquip(src))
 			switch(over_object.name)
 				if(BP_R_HAND)


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает

<!-- Вкратце опишите изменения, которые вносите. -->
<!-- Опишите **все** изменения, так как противное может сказаться на рассмотрении этого PR'а! -->
<!-- Если вы исправляете Issue, добавьте "Fixes #xxxx" (где xxxx - номер Issue) где-нибудь в описании PR'а. Это автоматически закроет Issue после принятия PR'а. -->

Фикс обновления интерфейса контейнера, когда вытаскивают контейнер из контейнера с помощью драг-энд-дропа.

## Changelog

:cl:
fix: Фикс обновления интерфейса контейнера, когда вытаскивают контейнер из контейнера с помощью драг-энд-дропа.
/:cl:

<!-- Оба :cl:'а должны быть на месте, что-бы чейнджлог работал! Вы можете написать свой ник справа от первого :cl:, если хотите. Иначе будет использован ваш ник на ГитХабе. -->
<!-- Вы можете использовать несколько записей с одинаковым префиксом (Они используются только для иконки в игре) и удалить ненужные. Помните, что чейнджлог должен быть понятен обычным игроком. -->
<!-- Если чейнджлог не влияет на игроков(например, это рефактор), вы можете исключить всю секцию. -->
