### PR TITLE
Move TGchat notifications to the top

### DIFF
--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,8 +5,8 @@
 
 .Notifications {
   position: absolute;
-  bottom: 1em;
-  left: 1em;
+  top: 1em;
+  left: 0.75em;
   right: 2em;
 }
 

--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -7,7 +7,7 @@
   position: absolute;
   top: 0.75em;
   left: 0.75em;
-  right: 1.75em;
+  right: 2em;
 }
 
 .Notification {

--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,9 +5,9 @@
 
 .Notifications {
   position: absolute;
-  top: 1em;
+  top: 0.75em;
   left: 0.75em;
-  right: 2em;
+  right: 1.75em;
 }
 
 .Notification {


### PR DESCRIPTION
<!-- Пишите **НИЖЕ** заголовков и **ВЫШЕ** комментариев, иначе что то может пойти не так. -->
<!-- Вы можете прочитать Contributing.MD, если хотите узнать больше. -->

## Что этот PR делает
Перемещает уведомления ТГчата наверх

## Почему это хорошо для игры
Можно нормально читать чат пока сервер загружается (Что очень долго)

## Изображения изменений
<details>
<summary>Скриншоты</summary>

![image](https://github.com/ss220club/WyccerraBay220/assets/69762909/ed8435ba-5021-4040-8a18-c7016c96e2e5)

</details>
